### PR TITLE
do not destroy those who have many

### DIFF
--- a/app/models/user_phenotype.rb
+++ b/app/models/user_phenotype.rb
@@ -1,5 +1,5 @@
 class UserPhenotype < ActiveRecord::Base
-  belongs_to :phenotype, dependent: :destroy
+  belongs_to :phenotype
   belongs_to :user
   validates_presence_of :variation
 


### PR DESCRIPTION
From the docs:

> :dependent
> If set to :destroy, the associated object is destroyed when this object is. If set to :delete, the associated object is deleted without calling its destroy method. This option should not be specified when belongs_to is used in conjunction with a has_many relationship on another class because of the potential to leave orphaned records behind.

Solves #36 (well, kind of)
