### PR TITLE
only load UserPhenotypes in need of fixing

### DIFF
--- a/lib/tasks/fix_phenotype_slashes.rake
+++ b/lib/tasks/fix_phenotype_slashes.rake
@@ -3,7 +3,7 @@
 namespace :phenotypes do
   desc "fixes broken phenotype-variations with '::' instead of '/'"
   task :fix_broken_slashes => :environment do
-    UserPhenotype.where("variation like '%::%'").find_each do |up|
+    UserPhenotype.where("variation like '%::%'").includes(:phenotype).find_each do |up|
       puts "Updating #{up.phenotype.characteristic}, #{up.variation}"
       # replace :: by /
       new_variation = up.variation.gsub("::","/")


### PR DESCRIPTION
May I propose this little change? Instead of loading all UserPhenotypes, it loads only those, that actually have a `::` in their variation.
