### PR TITLE
exclude debugger from CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 rvm:
   - 1.9.2
   - 1.9.3
-env: DB=postgres
+env: DB=postgres CI=1
 before_install: 
   - git clone git://github.com/redis/hiredis.git && cd hiredis && make && sudo make install && sudo ldconfig && cd ..
 before_script:

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ group :test do
   gem 'shoulda-context', require: false
   gem 'factory_girl'
   gem 'mocha', require: false
-  gem 'debugger'
+  gem 'debugger'  unless ENV['CI']
   gem 'sunspot_test', git: 'git://github.com/tsujigiri/sunspot_test.git', branch: 'dirty_quickfix'
   #gem "turn", "< 0.8.3" # truncates backtraces in the tests (bad)
 end


### PR DESCRIPTION
The compilation of the debugger gem's native extensions fails with Ruby 1.9.3 on Travis. As we don't need it there, this excludes it for Travis builds.
