### PR TITLE
preventing MendeleySearch from occupying all the memory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,6 @@ group :test do
   gem 'simplecov', require: false
 end
 
+group :development, :test do
+  gem 'uuidtools'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,6 +295,7 @@ GEM
     uglifier (2.1.2)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
+    uuidtools (2.1.4)
     vegas (0.1.11)
       rack (>= 1.0.0)
     warden (1.2.3)
@@ -351,6 +352,7 @@ DEPENDENCIES
   therubyracer
   twitter-bootstrap-rails
   uglifier
+  uuidtools
   vegas
   will_paginate
   yui-compressor

--- a/app/models/mendeley_paper.rb
+++ b/app/models/mendeley_paper.rb
@@ -1,7 +1,13 @@
 class MendeleyPaper < ActiveRecord::Base
    belongs_to :snp
+   validates_presence_of :title, :snp, :uuid
+   validates_uniqueness_of :uuid
 
    searchable do
       text :title
+   end
+
+   def first_author
+     read_attribute(:first_author).presence || "Unknown"
    end
 end

--- a/app/models/snp.rb
+++ b/app/models/snp.rb
@@ -2,7 +2,7 @@ class Snp < ActiveRecord::Base
   has_many :user_snps, foreign_key: :snp_name, primary_key: :name,
     dependent: :destroy
   has_many :plos_paper
-  has_many :mendeley_paper
+  has_many :mendeley_paper, dependent: :destroy
   has_many :snpedia_paper
   has_many :snp_comments
   has_many :genome_gov_paper
@@ -44,5 +44,4 @@ class Snp < ActiveRecord::Base
       Sidekiq::Client.enqueue(Frequency,s.id)
     end
   end
-  
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -277,9 +277,9 @@ ActiveRecord::Schema.define(:version => 20130904010950) do
     t.string   "allele_frequency"
     t.integer  "ranking"
     t.integer  "number_of_users",    :default => 0
-    t.datetime "mendeley_updated",   :default => '2013-07-31 12:44:49'
-    t.datetime "plos_updated",       :default => '2013-07-31 12:44:49'
-    t.datetime "snpedia_updated",    :default => '2013-07-31 12:44:49'
+    t.datetime "mendeley_updated",   :default => '2013-07-31 12:17:26'
+    t.datetime "plos_updated",       :default => '2013-07-31 12:17:26'
+    t.datetime "snpedia_updated",    :default => '2013-07-31 12:17:26'
     t.datetime "created_at",                                            :null => false
     t.datetime "updated_at",                                            :null => false
   end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -83,4 +83,13 @@ FactoryGirl.define do
     steps 100
     floors 1
   end
+
+  factory :mendeley_paper do
+    title "Musterstudie"
+    uuid { UUIDTools::UUID.random_create }
+    first_author "Max Mustermann"
+    mendeley_url "http://example.com"
+    doi "10.1000/182"
+    pub_year 2013
+  end
 end

--- a/test/unit/mendeley_search_test.rb
+++ b/test/unit/mendeley_search_test.rb
@@ -1,0 +1,123 @@
+require_relative '../test_helper'
+
+class MendeleySearchTest < ActiveSupport::TestCase
+  context "worker" do
+    setup do
+      @snp = FactoryGirl.build_stubbed(:snp, id: 1)
+      @worker = MendeleySearch.new
+      @document = {
+        "uuid"         => UUIDTools::UUID.random_create.to_s,
+        "title"        => "Test Driven Development And Why You Should Do It",
+        "authors"      => [{ "forename" => "Max", "surname" => "Mustermann" }],
+        "mendeley_url" => "http://example.com",
+        "year"         => "2013",
+        "doi"          => "456",
+      }
+    end
+
+    should "do nothing if snp does not exist" do
+      @worker.expects(:search).never
+      @worker.expects(:update_mendeley?).never
+      @worker.perform(0)
+    end
+
+    context "with existing snp" do
+      setup do
+        Snp.stubs(:where).returns(Snp)
+        Snp.stubs(:first).returns(@snp)
+      end
+
+      should "search for papers if the last update was too long ago" do
+        @worker.expects(:search)
+        @snp.stubs(:mendeley_updated).returns(32.days.ago)
+        @worker.perform(1)
+      end
+
+      should "not search for papers if the last update was not too long ago" do
+        @worker.expects(:search).never
+        @snp.stubs(:mendeley_updated).returns(30.days.ago)
+        @worker.perform(1)
+      end
+
+      should "search for papers if snp was never searched for" do
+        @worker.expects(:search)
+        @snp.stubs(:mendeley_updated).returns(nil)
+        @worker.perform(1)
+      end
+    end
+
+    context "searched-for papers" do
+      setup do
+        @worker.stubs(:snp).returns(@snp)
+      end
+
+      should "be processed" do
+        Mendeley::API::Documents.expects(:search).
+          with("\"#{@snp.name}\"", { items: 500, page: 0 }).
+          returns({ "documents" => [@document] })
+        @worker.expects(:process_documents).with([@document])
+
+        @snp.expects(:mendeley_updated=).with do |time|
+          assert time.is_a?(Time)
+        end
+        @snp.expects(:ranking=)
+        @snp.expects(:save).returns(true)
+
+        @worker.search
+      end
+    end
+
+    context "processing documents" do
+      setup do
+        @worker.stubs(:snp).returns(@snp)
+      end
+
+      should "create papers that do not already exist" do
+        uuid = @document["uuid"]
+        new_mendeley_paper = MendeleyPaper.new(uuid: uuid)
+        MendeleyPaper.expects(:find_or_initialize_by_uuid).with(uuid).
+          returns(new_mendeley_paper)
+        new_mendeley_paper.expects(:save).returns(true)
+        Sidekiq::Client.expects(:enqueue).with do |klass, id|
+          assert_equal(MendeleyDetails, klass)
+        end
+
+        @worker.process_documents([@document])
+
+        assert_equal @snp.id, new_mendeley_paper.snp_id
+        assert_equal @document["title"], new_mendeley_paper.title
+        assert_equal @document["mendeley_url"], new_mendeley_paper.mendeley_url
+        assert_equal "Max Mustermann", new_mendeley_paper.first_author
+        assert_equal @document["year"].to_i, new_mendeley_paper.pub_year
+        assert_equal @document["uuid"], new_mendeley_paper.uuid
+        assert_equal @document["doi"], new_mendeley_paper.doi
+      end
+
+      should "not update existing valid papers" do
+        uuid = @document["uuid"]
+        existing_mendeley_paper = FactoryGirl.
+          build_stubbed(:mendeley_paper, uuid: uuid, snp: @snp)
+        MendeleyPaper.expects(:find_or_initialize_by_uuid).with(uuid).
+          returns(existing_mendeley_paper)
+        MendeleyPaper.any_instance.expects(:save).never
+        Sidekiq::Client.expects(:enqueue).never
+
+        @worker.process_documents([@document])
+      end
+
+      should "update existing invalid papers" do
+        uuid = @document["uuid"]
+        existing_mendeley_paper = FactoryGirl.
+          build_stubbed(:mendeley_paper, snp: nil)
+        existing_mendeley_paper.expects(:save).returns(true)
+        MendeleyPaper.expects(:find_or_initialize_by_uuid).with(uuid).
+          returns(existing_mendeley_paper)
+        Sidekiq::Client.expects(:enqueue)
+
+        @worker.process_documents([@document])
+
+        assert_equal @snp.id, existing_mendeley_paper.snp_id
+      end
+    end
+  end
+end


### PR DESCRIPTION
It now processes each page of results before proceeding to the next one.
This way we shouldn't have any issue with this job sucking up all the
memory anymore, when there are a lot of results.
