### PR TITLE
fixing undefined method in mendeley details job

### DIFF
--- a/app/workers/mendeleydetails.rb
+++ b/app/workers/mendeleydetails.rb
@@ -10,12 +10,14 @@ class MendeleyDetails
      # Logging stuff
      Rails.logger.level = 0
      Rails.logger = Logger.new("#{Rails.root}/log/mendeleydetails_#{Rails.env}.log")
-     @mendeley_paper = MendeleyPaper.find_by_id(mendeley_paper_id.to_i)
+
+     mendeley_paper = MendeleyPaper.find_by_id(mendeley_paper_id.to_i)
+     return if mendeley_paper.nil?
 
      key_handle = File.open(::Rails.root.to_s+"/key_mendeley.txt")
      api_key = key_handle.readline.rstrip
 
-     detail_url = "http://api.mendeley.com/oapi/documents/details/" + @mendeley_paper.uuid + "/?consumer_key="+api_key
+     detail_url = "http://api.mendeley.com/oapi/documents/details/" + mendeley_paper.uuid + "/?consumer_key="+api_key
      begin
         detail_resp = Net::HTTP.get_response(URI.parse(detail_url))
      rescue
@@ -26,21 +28,21 @@ class MendeleyDetails
      detail_result = JSON.parse(detail_data)
 
      if detail_result["oa_journal"] != false
-        @mendeley_paper.open_access = true
+        mendeley_paper.open_access = true
      else
-        @mendeley_paper.open_access = false
+        mendeley_paper.open_access = false
      end
 
      log "mendeley details: updated oa- and reader-status\n"
      if detail_result["stats"]
-       @mendeley_paper.reader = detail_result["stats"]["readers"]
+       mendeley_paper.reader = detail_result["stats"]["readers"]
      elsif detail_result["reader"]
-       @mendeley_paper.reader = detail_result["reader"]
+       mendeley_paper.reader = detail_result["reader"]
      else
-       @mendeley_paper.reader = "Unknown"
+       mendeley_paper.reader = "Unknown"
      end
 
-     @mendeley_paper.save
+     mendeley_paper.save
      log "-> sleep for 5 secs\n"
      sleep(5)
   end


### PR DESCRIPTION
In order to prevent the MendeleyDetails job from retrying when the
requested MendeleyPaper is not found. I've seen this a lot in the
Sidekiq log.

I also removed a lot of '@'s because we don't need an instance variable here.
