### PR TITLE
Associate User with UserSnp via Genotype

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User < ActiveRecord::Base
   has_many :user_picture_phenotypes, :dependent => :destroy
   has_many :picture_phenotypes, :through => :user_picture_phenotypes
   has_many :genotypes, :dependent => :destroy
-  has_many :user_snps
+  has_many :user_snps, through: :genotypes
   has_many :snps, through: :user_snps
   has_many :homepages, dependent: :destroy
   has_many :messages, dependent: :destroy

--- a/app/models/user_snp.rb
+++ b/app/models/user_snp.rb
@@ -1,10 +1,9 @@
 class UserSnp < ActiveRecord::Base
   belongs_to :snp, foreign_key: :snp_name, primary_key: :name,
     counter_cache: true
-  belongs_to :user
+  has_one :user, through: :genotype
   belongs_to :genotype
 
   validates_presence_of :snp
-  validates_presence_of :user
   validates_presence_of :genotype
 end


### PR DESCRIPTION
First step towards removing the `user_id` column from the `user_snps` table
as in #121.
