### PR TITLE
Use lograge in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'bcrypt-ruby', :require => "bcrypt"
 gem 'sanitize'
 gem "recaptcha", :require => "recaptcha/rails"
 gem 'dynamic_form'
+gem 'lograge'
 
 # for errbit
 gem 'airbrake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,10 @@ GEM
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
+    lograge (0.3.0)
+      actionpack (>= 3)
+      activesupport (>= 3)
+      railties (>= 3)
     lumberjack (1.0.9)
     mail (2.5.4)
       mime-types (~> 1.16)
@@ -339,6 +343,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   json
+  lograge
   mediawiki-gateway
   mendeley!
   mocha

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,4 +58,6 @@ Snpr::Application.configure do
 
   # Generate digests for assets URLs
   config.assets.digest = true
+
+  config.lograge.enabled = true
 end


### PR DESCRIPTION
Since our production logs are a mess, I propose using https://github.com/roidrage/lograge which gets us single-line logs.
