### PR TITLE
Ignores SNPedia warnings until we update gems

### DIFF
--- a/app/workers/snpedia.rb
+++ b/app/workers/snpedia.rb
@@ -10,7 +10,7 @@ class Snpedia
   def perform(snp_id)
     @snp = Snp.find(snp_id)
     if snp && valid_snp_names.include?(snp.name) && snp.snpedia_updated < 31.days.ago
-      @client = MediaWiki::Gateway.new("http://bots.snpedia.com/api.php")
+      @client = MediaWiki::Gateway.new 'http://bots.snpedia.com/api.php', ignorewarnings: true
       perform_search
     end
   end


### PR DESCRIPTION
This just adds the ignorewarnings => true flag so that the logs aren't so huge until we implement the mediawiki-ruby-api gem (which is a hassle, no list() command as far as I can see)

(The list must be something like https://snpedia.com/api.php?action=query&list=search&srsearch="Rs1234(" )