### PR TITLE
Fixes problem with user phenotype updates

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -273,6 +273,7 @@ class UsersController < ApplicationController
       :message_on_new_phenotype,
       :message_on_phenotype_comment_reply,
       :message_on_snp_comment_reply,
+      user_phenotypes_attributes: [:id, :variation, :_destroy]
     )
   end
 end

--- a/app/views/users/_edit.html.erb
+++ b/app/views/users/_edit.html.erb
@@ -55,7 +55,7 @@
 		     });
 		   </script>
 		
-		 	<%= p.label Phenotype.find_by_id(p.object.phenotype_id).characteristic %><%= p.text_field :variation, id: "phenotype_"+p.object.phenotype_id.to_s%> <%= p.link_to_remove "Remove"%><br/>
+		 	<%= p.label Phenotype.find_by_id(p.object.phenotype_id).characteristic %><%= p.text_field :variation %> <%= p.link_to_remove "Remove"%><br/>
 	 	</div>
 <%end %>
 


### PR DESCRIPTION
Turns out, the strong parameters from Rails 4 were the culprit for #285, we just never realized. Users weren't able to update user-phenotypes or remove them. This should fix this.