### PR TITLE
Add a missing https to dalliance

### DIFF
--- a/app/views/snps/show.html.erb
+++ b/app/views/snps/show.html.erb
@@ -243,7 +243,7 @@
     },
 
     sources:     [{name:    'Genome',      
-      twoBitURI:            'http://www.biodalliance.org/datasets/hg38.2bit',
+      twoBitURI:            'https://www.biodalliance.org/datasets/hg38.2bit',
       tier_type:            'sequence'},
     {name:                  'Genes',     
       desc:                 'Gene structures from GENCODE 21',


### PR DESCRIPTION
My Firefox complains about `Blocked loading mixed active content "http://www.biodalliance.org/datasets/hg38.2bit"` when trying to load any snps/show page, this adds the https so that it'll work (hopefully? it's not testable on localhost) 