### PR TITLE
fixed references to emailing us

### DIFF
--- a/app/views/user_mailer/duplicate_file.html.erb
+++ b/app/views/user_mailer/duplicate_file.html.erb
@@ -14,7 +14,7 @@
     </p>
     <p>
       If there is no genotyping listed in your user-account, please contact us!</br>
-      If you need help, <a href="<%=faq_url()%>">you can read the FAQ</a> or contact us by replying to this mail.
+      If you need help, <a href="<%=faq_url()%>">you can read the FAQ</a> or email us at info@opensnp.org.
     </p>
     <p>
       Cheers,

--- a/app/views/user_mailer/duplicate_file.text.erb
+++ b/app/views/user_mailer/duplicate_file.text.erb
@@ -6,7 +6,7 @@ There was most-likely a mistake while uploading, leading to the same file being 
 
 If there is no genotyping listed in your user-account, please contact us!
 
-If you need help, you can read the FAQ <%=faq_url()%> or contact us by replying to this mail.
+If you need help, you can read the FAQ <%=faq_url()%> or email us at info@opensnp.org.
 
 Cheers,
 the openSNP team

--- a/app/views/user_mailer/file_has_mails.html.erb
+++ b/app/views/user_mailer/file_has_mails.html.erb
@@ -12,7 +12,7 @@
       The easiest way to fix this is to find out why your file contains email addresses, to remove these, and to re-upload it.
     </p>
     <p>
-      If you need help, <a href="<%=faq_url()%>">you can read the FAQ</a> or contact us by replying to this mail.
+      If you need help, <a href="<%=faq_url()%>">you can read the FAQ</a> or email us at info@opensnp.org.
     </p>
     <p>
       Cheers,

--- a/app/views/user_mailer/file_has_mails.text.erb
+++ b/app/views/user_mailer/file_has_mails.text.erb
@@ -4,7 +4,7 @@ You have recently uploaded a genotyping to our repository, but it looks like it 
 
 Some users have uploaded files with email addresses of strangers in the past, which we obviousy cannot allow. Therefore, we have deleted your genotyping. The easiest way to fix this is to find out why your file contains email addresses, to remove these, and to re-upload it.
 
-If you need help, you can read the FAQ <%=faq_url()%> or contact us by replying to this mail.
+If you need help, you can read the FAQ <%=faq_url()%> or email us at info@opensnp.org.
 
 Cheers,
 the openSNP team

--- a/app/views/user_mailer/no_dump.html.erb
+++ b/app/views/user_mailer/no_dump.html.erb
@@ -9,7 +9,7 @@
 You're receiving this mail because you requested to download a dump of all the genotypes in openSNP.org. Unfortunately, there are no genotypes yet. Maybe you want to upload your data?
     </p>
     <p>
-      If you need help <a href="<%=faq_url()%>">you can read the FAQ</a> or contact us by replying to this mail.
+      If you need help <a href="<%=faq_url()%>">you can read the FAQ</a> or email us at info@opensnp.org.
     </p>
     <p>
       Cheers,

--- a/app/views/user_mailer/no_genotyping_results.html.erb
+++ b/app/views/user_mailer/no_genotyping_results.html.erb
@@ -9,7 +9,7 @@
 	We're sorry to tell you that we don't have any users with uploaded genetic data that share the variation <%=@variation%> for <%=@phenotype_name%> yet.
     </p>
     <p>
-      If you need help, <a href="<%=faq_url()%>">you can read the FAQ</a> or contact us by replying to this mail.
+      If you need help, <a href="<%=faq_url()%>">you can read the FAQ</a> or email us at info@opensnp.org.
     </p>
     <p>
       Cheers,

--- a/app/views/user_mailer/parsing_error.html.erb
+++ b/app/views/user_mailer/parsing_error.html.erb
@@ -12,7 +12,7 @@
 
     </p>
     <p>
-      If you need help, <a href="<%=faq_url()%>">you can read the FAQ</a> or contact us by replying to this mail.
+      If you need help, <a href="<%=faq_url()%>">you can read the FAQ</a> or email us at info@opensnp.org.
     </p>
     <p>
       Cheers,

--- a/app/views/user_mailer/parsing_error.text.erb
+++ b/app/views/user_mailer/parsing_error.text.erb
@@ -4,7 +4,7 @@ We are sorry to inform you that there was at least one line in your genotyping f
 
 If this bug persists and you're sure that you set the correct filetype and the file is valid, please let us know. It's possible your DTC company changed the file-format they use.
 
-If you need some help, you can read the FAQ <%=faq_url()%> or contact us by replying to this mail.
+If you need some help, you can read the FAQ <%=faq_url()%> or email us at info@opensnp.org.
 
 Cheers,
 the openSNP team

--- a/app/views/user_mailer/password_reset_instructions.html.erb
+++ b/app/views/user_mailer/password_reset_instructions.html.erb
@@ -18,7 +18,7 @@
 
     </p>
     <p>
-      If you need help, <a href="<%=faq_url()%>">you can read the FAQ</a> or contact us by replying to this mail.
+      If you need help, <a href="<%=faq_url()%>">you can read the FAQ</a> or email us at info@opensnp.org.
     </p>
     <p>
       Cheers,

--- a/app/views/user_mailer/password_reset_instructions.text.erb
+++ b/app/views/user_mailer/password_reset_instructions.text.erb
@@ -10,7 +10,7 @@ If you did make this request just click the link below to reset your password:
 If the above URL does not work, try copying and pasting it into your browser.
 If you continue to have problems, please feel free to contact us.
 
-If you need help, you can read the FAQ <%=faq_url()%> or contact us by replying to this mail.
+If you need help, you can read the FAQ <%=faq_url()%> or email us at info@opensnp.org.
 
 Cheers,
 the openSNP team

--- a/app/views/user_mailer/welcome_user.html.erb
+++ b/app/views/user_mailer/welcome_user.html.erb
@@ -15,7 +15,7 @@
             <a href="<%=edit_user_url(@user)%>">To edit your settings, visit <%=edit_user_url(@user)%></a>
     </p>
     <p>
-      If you need help, <a href="<%=faq_url()%>">you can read the FAQ</a> or contact us by replying to this mail.
+      If you need help, <a href="<%=faq_url()%>">you can read the FAQ</a> or email us at info@opensnp.org.
     </p>
     <p>
       Cheers,


### PR DESCRIPTION
At some points in the emails we send to users we still referenced that they should just reply to these emails. But we changed this at some point, so that emails are no longer from `info@opensnp.org` but from `donotreply@opensnp.org`. I replaced those parts so that users now again know how to reach us. 