### PR TITLE
Fix genotype deletion

### DIFF
--- a/app/controllers/genotypes_controller.rb
+++ b/app/controllers/genotypes_controller.rb
@@ -51,18 +51,9 @@ class GenotypesController < ApplicationController
   end
 
   def destroy
-    user = current_user
-    genotype_count = user.genotypes.count
-    DeleteGenotype.perform_async(genotype_id: params[:id])
+    genotype = current_user.genotypes.find(params[:id])
+    DeleteGenotype.perform_async(genotype_id: genotype.id)
     flash[:notice] = 'Your Genotyping will be deleted. This may take a few minutes.'
-    if genotype_count == 1
-      # update user-attributes
-      user.update_attributes(has_sequence: false, sequence_link: nil)
-
-      # delete Uploaded Genotyping-achievement
-      achievement = Achievement.where(award: 'Published genotyping')
-      UserAchievement.where(achievement: achievement, user: user).destroy_all
-    end
     redirect_to current_user
   end
 

--- a/app/models/genotype.rb
+++ b/app/models/genotype.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 
 class Genotype < ActiveRecord::Base
   belongs_to :user
-  has_many :user_snps, dependent: :destroy
+  has_many :user_snps, dependent: :delete_all
   validates_presence_of :user
 
   has_attached_file :genotype, url: '/data/:fs_filename',

--- a/app/workers/delete_genotype.rb
+++ b/app/workers/delete_genotype.rb
@@ -3,6 +3,20 @@ class DeleteGenotype
   sidekiq_options queue: :user_snps, retry: 5, unique: true
 
   def perform(params)
-    Genotype.find_by!(id: params['genotype_id']).destroy
+    Genotype.transaction do
+      genotype = Genotype.find(params['genotype_id'])
+      user = genotype.user
+
+      if user.genotypes.count == 1
+        # update user-attributes
+        user.update_attributes(has_sequence: false, sequence_link: nil)
+
+        # delete Uploaded Genotyping-achievement
+        achievement = Achievement.where(award: 'Published genotyping')
+        UserAchievement.where(achievement: achievement, user: user).destroy_all
+      end
+
+      genotype.destroy
+    end
   end
 end


### PR DESCRIPTION
This changes the relationship between `Genotype` and `UserSnp`, so the `UserSnp`s get deleted in the database instead of being loaded and destroyed one by one. I also moved related logic into the worker.