### PR TITLE
Schedule updating papers once a month

### DIFF
--- a/app/controllers/snps_controller.rb
+++ b/app/controllers/snps_controller.rb
@@ -12,12 +12,6 @@ class SnpsController < ApplicationController
     @snp = Snp.includes(:snp_comments).
       where(name: params[:id].downcase).first || not_found
 
-    # TODO: Let's remove this here and use Snp.update_papers from a cron job
-    # instead. Shall we? - Helge
-    Sidekiq::Client.enqueue(PlosSearch, @snp.id)
-    Sidekiq::Client.enqueue(MendeleySearch, @snp.id)
-    Sidekiq::Client.enqueue(Snpedia, @snp.id)
-
     if params[:format] == 'json'
       users = @snp.users
       json_results = users.map do |u|

--- a/app/models/snp.rb
+++ b/app/models/snp.rb
@@ -25,18 +25,6 @@ class Snp < ActiveRecord::Base
     self.genotype_frequency ||= {}
   end
 
-  def self.update_papers
-    max_age = 31.days.ago
-
-    snps = Snp.select([ :id, :mendeley_updated, :snpedia_updated, :plos_updated ]).
-      where([ 'mendeley_updated < ? or snpedia_updated < ? or plos_updated < ?',
-              max_age, max_age, max_age ]).find_each do |snp|
-      Sidekiq::Client.enqueue(MendeleySearch, snp.id) if snp.mendeley_updated < max_age
-      Sidekiq::Client.enqueue(Snpedia, snp.id) if snp.snpedia_updated < max_age
-      Sidekiq::Client.enqueue(PlosSearch, snp.id) if snp.plos_updated < max_age
-    end
-  end
-
   def self.update_frequencies
     Snp.find_each do |s|
       Sidekiq::Client.enqueue(Frequency,s.id)

--- a/app/workers/update_papers.rb
+++ b/app/workers/update_papers.rb
@@ -6,7 +6,7 @@ class UpdatePapers
     MendeleySearch => 'mendeley_updated',
     PlosSearch => 'plos_updated',
     Snpedia => 'snpedia_updated'
-  }
+  }.freeze
 
   def perform
     PAPER_UPDATED_COLUMNS.each do |worker, column|

--- a/app/workers/update_papers.rb
+++ b/app/workers/update_papers.rb
@@ -1,5 +1,6 @@
 class UpdatePapers
   include Sidekiq::Worker
+  sidekiq_options retry: false, unique: true
   MAX_AGE = 31.days
 
   PAPER_UPDATED_COLUMNS = {

--- a/app/workers/update_papers.rb
+++ b/app/workers/update_papers.rb
@@ -1,0 +1,24 @@
+class UpdatePapers
+  include Sidekiq::Worker
+  MAX_AGE = 31.days
+
+  PAPER_UPDATED_COLUMNS = {
+    MendeleySearch => 'mendeley_updated',
+    PlosSearch => 'plos_updated',
+    Snpedia => 'snpedia_updated'
+  }
+
+  def perform
+    PAPER_UPDATED_COLUMNS.each do |worker, column|
+      Snp.where("#{column} < ?", max_age).pluck(:id).each do |snp_id|
+        worker.perform_async(snp_id)
+      end
+    end
+  end
+
+  private
+
+  def max_age
+    MAX_AGE.ago
+  end
+end

--- a/app/workers/update_papers.rb
+++ b/app/workers/update_papers.rb
@@ -11,13 +11,17 @@ class UpdatePapers
 
   def perform
     PAPER_UPDATED_COLUMNS.each do |worker, column|
-      Snp.where("#{column} < ?", max_age).pluck(:id).each do |snp_id|
+      snp_ids(column).each do |snp_id|
         worker.perform_async(snp_id)
       end
     end
   end
 
   private
+
+  def snp_ids(column)
+    Snp.where("#{column} < ?", max_age).pluck(:id)
+  end
 
   def max_age
     MAX_AGE.ago

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,3 +22,7 @@
 every :day, at: '1am' do
   rake 'dump:full', environment: 'production'
 end
+
+every :day do
+  rake 'papers:update'
+end

--- a/lib/tasks/update_papers.rake
+++ b/lib/tasks/update_papers.rake
@@ -1,6 +1,6 @@
 namespace :papers do
-  desc "update papers"
-  task :update => :environment do
-    Snp.update_papers
+  desc 'update papers'
+  task update: :environment do
+    UpdatePapers.perform_async
   end
 end

--- a/spec/workers/update_papers_spec.rb
+++ b/spec/workers/update_papers_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe UpdatePapers do
+  around { |e| Timecop.freeze(Time.current.beginning_of_minute, &e) }
+
+  let(:mendeley_snp_ids) { [1, 2, 3] }
+  let(:plos_snp_ids) { [4, 5, 6] }
+  let(:snpedia_snp_ids) { [7, 8, 9] }
+
+  it 'updates papers that have not been updated for MAX_AGE days' do
+    expect(Snp).to receive(:where).with('mendeley_updated < ?', 31.days.ago).and_return(Snp)
+    expect(Snp).to receive(:pluck).with(:id).and_return(mendeley_snp_ids)
+
+    expect(Snp).to receive(:where).with('plos_updated < ?', 31.days.ago).and_return(Snp)
+    expect(Snp).to receive(:pluck).with(:id).and_return(plos_snp_ids)
+
+    expect(Snp).to receive(:where).with('snpedia_updated < ?', 31.days.ago).and_return(Snp)
+    expect(Snp).to receive(:pluck).with(:id).and_return(snpedia_snp_ids)
+
+    expect(MendeleySearch).to receive(:perform_async).with(1)
+    expect(MendeleySearch).to receive(:perform_async).with(2)
+    expect(MendeleySearch).to receive(:perform_async).with(3)
+
+    expect(PlosSearch).to receive(:perform_async).with(4)
+    expect(PlosSearch).to receive(:perform_async).with(5)
+    expect(PlosSearch).to receive(:perform_async).with(6)
+
+    expect(Snpedia).to receive(:perform_async).with(7)
+    expect(Snpedia).to receive(:perform_async).with(8)
+    expect(Snpedia).to receive(:perform_async).with(9)
+
+    subject.perform
+  end
+end

--- a/test/unit/snp_test.rb
+++ b/test/unit/snp_test.rb
@@ -6,25 +6,6 @@ class SnpTest < ActiveSupport::TestCase
       @snp = FactoryGirl.create(:snp)
     end
 
-    context "papers" do
-      should "be updated when older than 31 days" do
-        @snp.mendeley_updated = @snp.snpedia_updated = @snp.plos_updated = 32.days.ago
-        @snp.save
-        queue = sequence('queue')
-        Sidekiq::Client.expects(:enqueue).with(MendeleySearch, @snp.id).in_sequence(queue)
-        Sidekiq::Client.expects(:enqueue).with(Snpedia, @snp.id).in_sequence(queue)
-        Sidekiq::Client.expects(:enqueue).with(PlosSearch, @snp.id).in_sequence(queue)
-        Snp.update_papers
-      end
-
-      should "not be updated when not older than 31 days" do
-        @snp.mendeley_updated = @snp.snpedia_updated = @snp.plos_updated = 30.days.ago
-        @snp.save
-        Sidekiq::Client.expects(:enqueue).never
-        Snp.update_papers
-      end
-    end
-
     should 'sum up genotype frequencies' do
       @snp.update_attribute(
         :genotype_frequency,


### PR DESCRIPTION
Instead of updating the papers for each SNP whenever their page gets requested, update the papers of all SNPs if they haven't been for a month.