### PR TITLE
Move Frequency jobs to frequency queue

### DIFF
--- a/app/workers/frequency.rb
+++ b/app/workers/frequency.rb
@@ -1,6 +1,6 @@
 class Frequency
   include Sidekiq::Worker
-  sidekiq_options queue: :user_snps, retry: 5, unique: true
+  sidekiq_options queue: :frequency, retry: 5, unique: true
 
   def perform(snp_id)
     Snp.reset_counters(snp_id, :user_snps)

--- a/db/migrate/20160626121340_move_frequency_jobs_to_frequency_queue.rb
+++ b/db/migrate/20160626121340_move_frequency_jobs_to_frequency_queue.rb
@@ -1,0 +1,10 @@
+class MoveFrequencyJobsToFrequencyQueue < ActiveRecord::Migration
+  def change
+    Sidekiq::Queue.new('user_snps').each do |job|
+      if job.klass == 'Frequency'
+        Frequency.perform_async(*job.args)
+        job.delete
+      end
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1971,3 +1971,5 @@ INSERT INTO schema_migrations (version) VALUES ('20151119070640');
 
 INSERT INTO schema_migrations (version) VALUES ('20160207043305');
 
+INSERT INTO schema_migrations (version) VALUES ('20160626121340');
+


### PR DESCRIPTION
In order to not block the parsing jobs, move the frequency jobs to a
different queue.