### PR TITLE
decreases calls to DB when vieweing phenotypes index

### DIFF
--- a/app/controllers/phenotypes_controller.rb
+++ b/app/controllers/phenotypes_controller.rb
@@ -3,11 +3,11 @@ class PhenotypesController < ApplicationController
   helper_method :sort_column, :sort_direction
 
   def index
-    @title = "Listing all phenotypes"
+    @title = 'Listing all phenotypes'
 
-    @phenotypes = Phenotype.
-      order(sort_column + " " + sort_direction).
-      includes(:user_phenotypes)
+    @phenotypes = Phenotype
+      .order(sort_column + ' ' + sort_direction)
+      .includes(:user_phenotypes)
 
     @phenotypes_paginate = @phenotypes.paginate(:page => params[:page], :per_page => 10)
 

--- a/app/controllers/phenotypes_controller.rb
+++ b/app/controllers/phenotypes_controller.rb
@@ -9,7 +9,7 @@ class PhenotypesController < ApplicationController
       .order(sort_column + ' ' + sort_direction)
       .includes(:user_phenotypes)
 
-    @phenotypes_paginate = @phenotypes.paginate(:page => params[:page], :per_page => 10)
+    @phenotypes_paginate = @phenotypes.paginate(page: params[:page], per_page: 10)
 
     respond_to do |format|
       format.html
@@ -17,12 +17,12 @@ class PhenotypesController < ApplicationController
       format.json do
         phenotypes_json =
           @phenotypes.find_each.map do |p|
-            phenotype = {}
-            phenotype['id'] = p.id
-            phenotype['characteristic'] = p.characteristic
-            phenotype['known_variations'] = p.known_phenotypes
-            phenotype['number_of_users'] = p.user_phenotypes.length
-            phenotypes_json << phenotype
+            {
+              id: p.id,
+              characteristic: p.characteristic,
+              known_variations: p.known_phenotypes,
+              number_of_users: p.user_phenotypes.count
+            }
           end
         render :json => phenotypes_json
       end

--- a/app/controllers/phenotypes_controller.rb
+++ b/app/controllers/phenotypes_controller.rb
@@ -4,21 +4,26 @@ class PhenotypesController < ApplicationController
 
   def index
     @title = "Listing all phenotypes"
+
     @phenotypes = Phenotype.order(sort_column + " " + sort_direction)
-    @phenotypes_paginate = @phenotypes.paginate(:page => params[:page],:per_page => 10)
-    @phenotypes_json = []
-    @phenotypes.each do |p|
-      @phenotype = {}
-      @phenotype["id"] = p.id
-      @phenotype["characteristic"] = p.characteristic
-      @phenotype["known_variations"] = p.known_phenotypes
-      @phenotype["number_of_users"] = p.user_phenotypes.length
-      @phenotypes_json << @phenotype
-    end
+
+    @phenotypes_paginate = @phenotypes.paginate(:page => params[:page], :per_page => 10)
+
     respond_to do |format|
       format.html
       format.xml 
-      format.json {render :json => @phenotypes_json} 
+      format.json do
+        phenotypes_json =
+          @phenotypes.find_each.map do |p|
+            phenotype = {}
+            phenotype['id'] = p.id
+            phenotype['characteristic'] = p.characteristic
+            phenotype['known_variations'] = p.known_phenotypes
+            phenotype['number_of_users'] = p.user_phenotypes.length
+            phenotypes_json << phenotype
+          end
+        render :json => phenotypes_json
+      end
     end
   end
 

--- a/app/controllers/phenotypes_controller.rb
+++ b/app/controllers/phenotypes_controller.rb
@@ -5,7 +5,9 @@ class PhenotypesController < ApplicationController
   def index
     @title = "Listing all phenotypes"
 
-    @phenotypes = Phenotype.order(sort_column + " " + sort_direction)
+    @phenotypes = Phenotype.
+      order(sort_column + " " + sort_direction).
+      includes(:user_phenotypes)
 
     @phenotypes_paginate = @phenotypes.paginate(:page => params[:page], :per_page => 10)
 


### PR DESCRIPTION
Indexing phenotypes is slow. I believe this is due to looping over the entire table at least once to build a JSON object which I don't think is even being used by the html or xml views.

- Moved the JSON generating code within the json block so it doesn't run when rendering HTML
- Changed the `each` loop to a `find_each` loop used in generating the JSON. This causes phenotypes to be fetched in batches.
- Eager load `user_phenotypes` to reduce DB calls.