### PR TITLE
seeds development db with some phenotypes

### DIFF
--- a/db/development_seeds.rb
+++ b/db/development_seeds.rb
@@ -1,0 +1,37 @@
+BODY_PARTS = %w{
+  hair
+  head
+  eyebrow
+  eyelash
+  eye
+  ear
+  nose
+  nostril
+  mouth
+  teeth
+  tongue
+  forearm
+  hand
+  finger
+  fingernail
+  thumb
+  torso
+  buttocks
+  leg
+  knee
+  heal
+  foot
+  toe
+  toenail
+}.freeze
+
+PROPERTIES = %w{
+  length
+  width
+  color
+  size
+}.freeze
+
+100.times do
+  Phenotype.create! characteristic: "#{BODY_PARTS.sample} #{PROPERTIES.sample}"
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,3 +27,5 @@ if Achievement.all.length == 0
 	    ('Created 10 new phenotypes', '10addphen', '#{time.iso8601}', '#{time.iso8601}')
   SQL
 end
+
+load 'db/development_seeds.rb' if Rails.env.development?


### PR DESCRIPTION
Running `rake db:seed` will not create 100 phenotypes. Useful for testing.