### PR TITLE
removes username and password from DB

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,7 +1,5 @@
 base: &base
   adapter: postgresql
-  username: snpr
-  password: secret
   pool: 25
   
 development:


### PR DESCRIPTION
These are usually blank by default. Adds an extra step when getting setup for development.