### PR TITLE
reduces calls to DB for indexing genotypes

### DIFF
--- a/app/controllers/genotypes_controller.rb
+++ b/app/controllers/genotypes_controller.rb
@@ -5,8 +5,11 @@ class GenotypesController < ApplicationController
 
   def index
     @title = "Listing all genotypings"
-    @genotypes = Genotype.order("#{sort_column} #{sort_direction}")
-    @genotypes_paginate = @genotypes.paginate(page: params[:page],per_page: 20)
+    @genotypes =
+      Genotype
+        .includes(:user)
+        .order("#{sort_column} #{sort_direction}")
+    @genotypes_paginate = @genotypes.paginate(page: params[:page], per_page: 20)
   end
 
   def new

--- a/app/controllers/genotypes_controller.rb
+++ b/app/controllers/genotypes_controller.rb
@@ -7,8 +7,8 @@ class GenotypesController < ApplicationController
     @title = "Listing all genotypings"
     @genotypes =
       Genotype
-        .includes(:user)
-        .order("#{sort_column} #{sort_direction}")
+      .includes(:user)
+      .order("#{sort_column} #{sort_direction}")
     @genotypes_paginate = @genotypes.paginate(page: params[:page], per_page: 20)
   end
 

--- a/app/views/genotypes/index.html.erb
+++ b/app/views/genotypes/index.html.erb
@@ -15,7 +15,6 @@
 <br/>
 <table class="table table-striped" id="all_genotypes">
   <tr>
-    <th>#</th>
     <th><%= sortable "id", "ID"%></th>
     <th>User</th>
     <th><%= sortable "filetype", "Type"%></th>
@@ -24,13 +23,12 @@
   </tr>
   <% @genotypes_paginate.each do |g| %>
     <tr>
-    <td><%= Genotype.all.sort { |a,b| a.id <=> b.id }.index(g) + 1 %></td>
-    <td><%= g.id %></td>
-    <td><%=image_tag g.user.avatar.url(:head),:style => "vertical-align:middle"%> <%= link_to(g.user.name, g.user)%></td>
-    <td><%= g.filetype %></td>
-    <td><%= g.created_at%></td>
-    <td><%= link_to "Right-click and 'Save as..'", '../data/' + g.fs_filename  %></td>
-  </tr>
-<% end %>
+      <td><%= g.id %></td>
+      <td><%=image_tag g.user.avatar.url(:head),:style => "vertical-align:middle"%> <%= link_to(g.user.name, g.user)%></td>
+      <td><%= g.filetype %></td>
+      <td><%= g.created_at%></td>
+      <td><%= link_to "Right-click and 'Save as..'", '../data/' + g.fs_filename  %></td>
+    </tr>
+  <% end %>
 </table>
 <%= page_navigation_links @genotypes_paginate %>


### PR DESCRIPTION
- pre-fetch users
- remove call to `Genotype.all` in index view which was causing `n_row` calls to `Genotype.all`. Do you really need the `#` column? If so, I can use `#each_with_index` or something instead.