### PR TITLE
added survey-email feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,11 @@ export MENDELEY_CONSUMER_KEY=foo
 export ERRBIT_API_KEY=foo
 export ERRBIT_HOST=localhost
 
+# username for smtp
 export SURVEY_EMAIL_USER=foobar
+# pw for smtp
 export SURVEY_EMAIL_PASSWORD=foobar
+# server-address for smtp
 export SURVEY_EMAIL_ADDRESS=foobar
+# port for smtp
 export SURVEY_EMAIL_PORT=foobar

--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,8 @@ export SIDEKIQ_PASSWORD=foo
 export MENDELEY_CONSUMER_KEY=foo
 export ERRBIT_API_KEY=foo
 export ERRBIT_HOST=localhost
+
+export SURVEY_EMAIL_USER=foobar
+export SURVEY_EMAIL_PASSWORD=foobar
+export SURVEY_EMAIL_ADDRESS=foobar
+export SURVEY_EMAIL_PORT=foobar

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -76,10 +76,10 @@ default :from => "donotreply@opensnp.org"
 
 	def survey(user)
 		@user = user
-		delivery_options = { user_name: ENV.fetch('SURVEY_EMAIL_USER'),
-                         password: ENV.fetch('SURVEY_EMAIL_PASSWORD'),
-                         address: ENV.fetch('SURVEY_EMAIL_ADDRESS'),
-												 port: ENV.fetch('SURVEY_EMAIL_PORT') }
+		delivery_options = { 	user_name: ENV.fetch('SURVEY_EMAIL_USER'),
+													password: ENV.fetch('SURVEY_EMAIL_PASSWORD'),
+													address: ENV.fetch('SURVEY_EMAIL_ADDRESS'),
+													port: ENV.fetch('SURVEY_EMAIL_PORT') }
 		mail(:subject => "openSNP: A one-question survey on height", :to => @user.email,:from => "survey@opensnp.org",delivery_method_options: delivery_options)
 	end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -74,6 +74,15 @@ default :from => "donotreply@opensnp.org"
     mail(:subject => "openSNP meets crowdAI: Crowdsourcing the Prediction of Phenotypes from Genotypes", :to => @user.email)
   end
 
+	def survey(user)
+		@user = user
+		delivery_options = { user_name: ENV.fetch('SURVEY_EMAIL_USER'),
+                         password: ENV.fetch('SURVEY_EMAIL_PASSWORD'),
+                         address: ENV.fetch('SURVEY_EMAIL_ADDRESS'),
+												 port: ENV.fetch('SURVEY_EMAIL_PORT') }
+		mail(:subject => "openSNP: A one-question survey on height", :to => @user.email,:from => "survey@opensnp.org")
+	end
+
   def dump(target_address, link)
     @link = link
     mail(:subject => "openSNP.org: The data dump you requested is ready to be downloaded",:to => target_address)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -80,7 +80,7 @@ default :from => "donotreply@opensnp.org"
                          password: ENV.fetch('SURVEY_EMAIL_PASSWORD'),
                          address: ENV.fetch('SURVEY_EMAIL_ADDRESS'),
 												 port: ENV.fetch('SURVEY_EMAIL_PORT') }
-		mail(:subject => "openSNP: A one-question survey on height", :to => @user.email,:from => "survey@opensnp.org")
+		mail(:subject => "openSNP: A one-question survey on height", :to => @user.email,:from => "survey@opensnp.org",delivery_method_options: delivery_options)
 	end
 
   def dump(target_address, link)

--- a/app/views/user_mailer/survey.html.erb
+++ b/app/views/user_mailer/survey.html.erb
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    Dear <%=@user.name%>,
+    <p>
+      This is just a friendly reminder[1] that <i>openSNP</i> is currently designing an interesting project with <a href=" https://www.crowdai.org/"><i>crowdAI</i></a>, an open research platform developed by scientists at EPFL, Switzerland. Enabling researchers to find new associations between gene variants and human traits has for a long time been our goal, and together we’re now taking the first steps in this direction.
+    </p>
+    <p>
+      We will run an open, crowdsourced challenge to see if computer algorithms can be developed to predict individual height. Traditional genetics approaches have focused on identifying individual variants that contribute to such traits, and while quite successful, they have been unable to explain a large fraction of the differences observed between individuals. A new method called “deep learning”, where computers can learn complex patterns from existing data, has recently led to breakthroughs in areas such as image and text recognition. We think this method may have the same potential for genetics.
+    </p>
+    <p>
+      In order to show how crowdsourced citizen science can move genetics forward, we would love to get your height from a standardized form. This is why we kindly ask you to fill in <a href="https://docs.google.com/forms/d/e/1FAIpQLSdOG0tZUaw1gD6MaFetjqyM6_jpwEgL74DnY15l9-hSZTalbA/viewform?entry.28571329=<%=@user.id%>">this one question survey</a> (it will not even take you a minute to answer!). : <a href="https://docs.google.com/forms/d/e/1FAIpQLSdOG0tZUaw1gD6MaFetjqyM6_jpwEgL74DnY15l9-hSZTalbA/viewform?entry.28571329=<%=@user.id%>">Survey at Google Docs</a>.
+    </p>
+    <p>
+      Thanks so much for your support! If you have any questions regarding this research you can always contact us at info@openSNP.org or info@crowdAI.org.
+    </p>
+    <p>
+      The openSNP team and the crowdAI team
+    </p>
+    <p>
+      [1] This might also be the first email you get regarding this, as our email system had some problem with getting blacklisted by GMail
+    </p>
+      --
+      <br/>
+      You're receiving this email as your openSNP-settings say that you're okay with getting some emails from the openSNP-team. You can change this setting really easy at https://opensnp.org/users/<%=@user.id%>/edit#notifications</br></br>
+  </body>
+</html>

--- a/app/views/user_mailer/survey.text.erb
+++ b/app/views/user_mailer/survey.text.erb
@@ -1,0 +1,16 @@
+Dear <%=@user.name%>,
+
+This is just a friendly reminder[1] that openSNP is currently designing an interesting project with crowdAI (https://www.crowdai.org/), an open research platform developed by scientists at EPFL, Switzerland. Enabling researchers to find new associations between gene variants and human traits has for a long time been our goal, and together we’re now taking the first steps in this direction.
+
+We will run an open, crowdsourced challenge to see if computer algorithms can be developed to predict individual height. Traditional genetics approaches have focused on identifying individual variants that contribute to such traits, and while quite successful, they have been unable to explain a large fraction of the differences observed between individuals. A new method called “deep learning”, where computers can learn complex patterns from existing data, has recently led to breakthroughs in areas such as image and text recognition. We think this method may have the same potential for genetics.
+
+In order to show how crowdsourced citizen science can move genetics forward, we would love to get your height from a standardized form. This is why we kindly ask you to fill in this one question survey (it will not even take you a minute to answer!). : https://docs.google.com/forms/d/e/1FAIpQLSdOG0tZUaw1gD6MaFetjqyM6_jpwEgL74DnY15l9-hSZTalbA/viewform?entry.28571329=<%=@user.id%>
+
+Thanks so much for your support! If you have any questions regarding this research you can always contact us at info@openSNP.org or info@crowdAI.org.
+
+The openSNP team and the crowdAI team
+
+[1] This might also be the first email you get regarding this, as our email system had some problem with getting blacklisted by GMail
+
+--
+You're receiving this email as your openSNP-settings say that you're okay with getting some emails from the openSNP-team. You can change this setting really easy at https://opensnp.org/users/<%=@user.id%>/edit#notifications

--- a/lib/tasks/send_survey.rake
+++ b/lib/tasks/send_survey.rake
@@ -1,0 +1,27 @@
+namespace :survey do
+  desc "send survey"
+  task :send => :environment do
+    # invoke script with rake survey:send EXCLUDEFILE=/path/to/file.txt
+    # read list of users to exclude
+    # should contain one user-ID per line
+    if ENV['EXCLUDEFILE']
+      exclude_users = File.readlines(ENV['EXCLUDEFILE']).each {|l| l.chomp!}
+    else
+      exclude_users = []
+    end
+
+    # send survey to each user that
+    # a) allows us emailing them
+    # b) has genetic data
+    # c) is not already in the DB
+    User.where(:message_on_newsletter => true).find_each do |u|
+      unless exclude_users.include?u.id.to_s
+        if u.genotypes.length > 0
+          UserMailer.survey(u).deliver_now
+          # wait for one minute so we don't crash the google mail daily limit
+          sleep(1.minutes)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/send_survey.rake
+++ b/lib/tasks/send_survey.rake
@@ -4,10 +4,10 @@ namespace :survey do
     # invoke script with rake survey:send EXCLUDEFILE=/path/to/file.txt
     # read list of users to exclude
     # should contain one user-ID per line
-    if ENV['EXCLUDEFILE']
-      exclude_users = File.readlines(ENV['EXCLUDEFILE']).map(&:chomp!)
+    exclude_users = if ENV['EXCLUDEFILE']
+      File.readlines(ENV['EXCLUDEFILE']).map(&:chomp!)
     else
-      exclude_users = []
+      []
     end
 
     # send survey to each user that
@@ -16,7 +16,7 @@ namespace :survey do
     # c) is not already in the DB
     User.where(:message_on_newsletter => true).find_each do |u|
       unless exclude_users.include?u.id.to_s
-        if u.genotypes.length > 0
+        unless u.genotypes.empty?
           UserMailer.survey(u).deliver_now
           # wait for one minute so we don't crash the google mail daily limit
           sleep(1.minute)

--- a/lib/tasks/send_survey.rake
+++ b/lib/tasks/send_survey.rake
@@ -1,11 +1,11 @@
 namespace :survey do
-  desc "send survey"
+  desc 'send survey'
   task :send => :environment do
     # invoke script with rake survey:send EXCLUDEFILE=/path/to/file.txt
     # read list of users to exclude
     # should contain one user-ID per line
     if ENV['EXCLUDEFILE']
-      exclude_users = File.readlines(ENV['EXCLUDEFILE']).each {|l| l.chomp!}
+      exclude_users = File.readlines(ENV['EXCLUDEFILE']).map { |l| l.chomp! }
     else
       exclude_users = []
     end
@@ -19,7 +19,7 @@ namespace :survey do
         if u.genotypes.length > 0
           UserMailer.survey(u).deliver_now
           # wait for one minute so we don't crash the google mail daily limit
-          sleep(1.minutes)
+          sleep(1.minute)
         end
       end
     end

--- a/lib/tasks/send_survey.rake
+++ b/lib/tasks/send_survey.rake
@@ -5,10 +5,10 @@ namespace :survey do
     # read list of users to exclude
     # should contain one user-ID per line
     exclude_users = if ENV['EXCLUDEFILE']
-      File.readlines(ENV['EXCLUDEFILE']).map(&:chomp!)
-    else
-      []
-    end
+                      File.readlines(ENV['EXCLUDEFILE']).map(&:chomp!)
+                    else
+                      []
+                    end
 
     # send survey to each user that
     # a) allows us emailing them

--- a/lib/tasks/send_survey.rake
+++ b/lib/tasks/send_survey.rake
@@ -5,7 +5,7 @@ namespace :survey do
     # read list of users to exclude
     # should contain one user-ID per line
     if ENV['EXCLUDEFILE']
-      exclude_users = File.readlines(ENV['EXCLUDEFILE']).map { |l| l.chomp! }
+      exclude_users = File.readlines(ENV['EXCLUDEFILE']).map(&:chomp!)
     else
       exclude_users = []
     end


### PR DESCRIPTION
In order to re-send the survey emails for crowdAI, this time from survey@opensnp.org we need

1. a way to set up the new email address alongside the other one
2. a way to only send to people who haven't answered that survey already
3 a way to exclude people who have no genetic data uploaded

I implemented 1. by adding the specific settings to the `.env` and created a `survey` mailer-definition that uses these `ENV` settings (see .env.example). 

For 2. and 3. I added a new rake task `survey:send` that can be run with or without specifying a list of users that should not get the survey emails. 

To run the task solitarily just run `rake survey:send`. To exclude a list of users you can run `rake survey:send EXCLUDEFILE=/path/to/file.txt` with `file.txt`containing one user-ID per line. 

Do you think that makes sense?