### PR TITLE
Adds check in zipping when file does not exist 

### DIFF
--- a/app/workers/zipfulldata.rb
+++ b/app/workers/zipfulldata.rb
@@ -254,7 +254,7 @@ TXT
       end
 
       zipfile.add("user#{gen_file.user_id}_file#{gen_file.id}_yearofbirth_#{yob}_sex_#{sex}.#{gen_file.filetype}.txt",
-                  to_zip_file) unless ! File.exist? to_zip_file
+                  to_zip_file) unless !File.exist? to_zip_file
     end
   end
 

--- a/app/workers/zipfulldata.rb
+++ b/app/workers/zipfulldata.rb
@@ -253,12 +253,8 @@ TXT
           sex = "unknown"
       end
 
-      if not File.exist? to_zip_file
-        next
-      end
-
       zipfile.add("user#{gen_file.user_id}_file#{gen_file.id}_yearofbirth_#{yob}_sex_#{sex}.#{gen_file.filetype}.txt",
-                  to_zip_file)
+                  to_zip_file) unless ! File.exist? to_zip_file
     end
   end
 

--- a/app/workers/zipfulldata.rb
+++ b/app/workers/zipfulldata.rb
@@ -244,14 +244,21 @@ TXT
     genotypes.each do |gen_file|
       yob = gen_file.user.yearofbirth
       sex = gen_file.user.sex
+      to_zip_file = "#{Rails.root}/public/data/#{gen_file.fs_filename}"
+
       if yob == "rather not say"
           yob = "unknown"
       end
       if sex == "rather not say"
           sex = "unknown"
       end
+
+      if not File.exist? to_zip_file
+        next
+      end
+
       zipfile.add("user#{gen_file.user_id}_file#{gen_file.id}_yearofbirth_#{yob}_sex_#{sex}.#{gen_file.filetype}.txt",
-                  "#{Rails.root}/public/data/#{gen_file.fs_filename}")
+                  to_zip_file)
     end
   end
 


### PR DESCRIPTION
This can happen when a genotyping was deleted and removed from disk, but the genotyping's entry in db is still there.
