### PR TITLE
survey results + openhumans for mailing

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -81,7 +81,7 @@ default :from => "donotreply@opensnp.org"
 													password: ENV.fetch('SURVEY_EMAIL_PASSWORD'),
 													address: ENV.fetch('SURVEY_EMAIL_ADDRESS'),
 													port: ENV.fetch('SURVEY_EMAIL_PORT') }
-		mail(:subject => "openSNP: A one-question survey on height", :to => @user.email,:from => "survey@opensnp.org",delivery_method_options: delivery_options)
+		mail(:subject => "openSNP: Read our survey results and meet Open Humans", :to => @user.email,:from => "survey@opensnp.org" ,delivery_method_options: delivery_options)
 	end
 
   def dump(target_address, link)

--- a/app/views/user_mailer/survey.html.erb
+++ b/app/views/user_mailer/survey.html.erb
@@ -6,22 +6,49 @@
   <body>
     Dear <%=@user.name%>,
     <p>
-      This is just a friendly reminder[1] that <i>openSNP</i> is currently designing an interesting project with <a href=" https://www.crowdai.org/"><i>crowdAI</i></a>, an open research platform developed by scientists at EPFL, Switzerland. Enabling researchers to find new associations between gene variants and human traits has for a long time been our goal, and together we’re now taking the first steps in this direction.
+      Today we’d like to reach out to you with two topics that might interest you:
     </p>
     <p>
-      We will run an open, crowdsourced challenge to see if computer algorithms can be developed to predict individual height. Traditional genetics approaches have focused on identifying individual variants that contribute to such traits, and while quite successful, they have been unable to explain a large fraction of the differences observed between individuals. A new method called “deep learning”, where computers can learn complex patterns from existing data, has recently led to breakthroughs in areas such as image and text recognition. We think this method may have the same potential for genetics.
+      The first is a survey about your motivations, fears and experiences about participating in openSNP, which we did along with researchers from the University of Zurich, <a href="http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0177158">was finally published in PLOS ONE</a>. If you want to dive into the survey data itself you’ll find all you need there as well!
     </p>
     <p>
-      In order to show how crowdsourced citizen science can move genetics forward, we would love to get your height from a standardized form. This is why we kindly ask you to fill in <a href="https://docs.google.com/forms/d/e/1FAIpQLSdOG0tZUaw1gD6MaFetjqyM6_jpwEgL74DnY15l9-hSZTalbA/viewform?entry.28571329=<%=@user.id%>">this one question survey</a> (it will not even take you a minute to answer!). : <a href="https://docs.google.com/forms/d/e/1FAIpQLSdOG0tZUaw1gD6MaFetjqyM6_jpwEgL74DnY15l9-hSZTalbA/viewform?entry.28571329=<%=@user.id%>">Survey at Google Docs</a>.
+      The second thing we want to highlight is what Open Humans is doing. They are a non-profit community that enables sharing your data sets and connecting you with researchers and citizen scientists. Currently there are two projects about genetic data interpretation and visualization that might be of interest to you. <i>Open Humans</i> Co-founder Madeleine Ball wrote a brief introduction about the platform itself and the projects that might be of interest to you. You can find it below.
     </p>
     <p>
-      Thanks so much for your support! If you have any questions regarding this research you can always contact us at info@openSNP.org or info@crowdAI.org.
+      Until next time,
     </p>
     <p>
-      The openSNP team and the crowdAI team
+      Philipp and Bastian, for the openSNP-team
     </p>
     <p>
-      [1] This might also be the first email you get regarding this, as our email system had some problem with getting blacklisted by GMail
+      Dear openSNP member,
+    </p>
+    <p>
+      I'd like to invite you to become a member of Open Humans, and highlight two projects in <a href="https://www.openhumans.org/">Open Humans</a> that may be of particular interest or value to openSNP members.
+    </p>
+    <p>
+      Open Humans is a nonprofit platform and community that gives you an ongoing profile for connecting and sharing your genetic and other data. We also make it easy for researchers and citizen scientists to create projects that others can join – enabling you to explore data and contribute to research in new ways.
+    </p>
+    <p>
+      There are two projects in Open Humans you might be interested in, as they specifically invite individuals publicly sharing their genetic data:
+    </p>
+    <p>
+      <a href="https://www.openhumans.org/activity/genomix-genome-exploration/">GenomiX Genome Exploration</a>: Interested in genome data visualization? If you're already someone publicly sharing your 23andMe data, there's a research team that would love to work with you. A team led by Orit Shaer (Wellesley) and Oded Nov (NYU) have developed a genetic data exploration tool. Join their project and they'll invite you to participate in an online study this Spring/Summer that uses your own genetic data.
+    </p>
+    <p>
+      <a href="https://www.openhumans.org/activity/genevieve-genome-report/">Genevieve Genome Report</a>: Genevieve is a tool that matches your data against ClinVar, a public database that aggregates information about genetic variants. To help improve shared understanding, Genevieve also invites users to contribute to shared, public, wiki-style notes. Because Genevieve uses a different matching algorithm, it has the potential to discover new information not available in your OpenSNP report.
+    </p>
+    <p>
+      More about Open Humans: Launched in 2015, Open Humans is a program of the US-based 501(c)(3) nonprofit Open Humans Foundation (formerly called PersonalGenomes.org). Although it is not a study in itself, Open Humans allows you to join studies from a variety of academic institutions. In addition, members that join the optional Public Data Sharing study are able to publicly share data on the site, which is necessary for the two projects highlighted here. You can contact Open Humans for more information by emailing support@openhumans.org.
+    </p>
+    <p>
+      Sincerely,
+    </p>
+    <p>
+      Madeleine Ball, PhD
+    </p>
+    <p>
+      Open Humans Co-founder Open Humans Foundation, Director of Research
     </p>
       --
       <br/>

--- a/app/views/user_mailer/survey.text.erb
+++ b/app/views/user_mailer/survey.text.erb
@@ -1,16 +1,37 @@
 Dear <%=@user.name%>,
 
-This is just a friendly reminder[1] that openSNP is currently designing an interesting project with crowdAI (https://www.crowdai.org/), an open research platform developed by scientists at EPFL, Switzerland. Enabling researchers to find new associations between gene variants and human traits has for a long time been our goal, and together we’re now taking the first steps in this direction.
+Today we’d like to reach out to you with two topics that might interest you:
 
-We will run an open, crowdsourced challenge to see if computer algorithms can be developed to predict individual height. Traditional genetics approaches have focused on identifying individual variants that contribute to such traits, and while quite successful, they have been unable to explain a large fraction of the differences observed between individuals. A new method called “deep learning”, where computers can learn complex patterns from existing data, has recently led to breakthroughs in areas such as image and text recognition. We think this method may have the same potential for genetics.
+The first is a survey about your motivations, fears and experiences about participating in openSNP, which we did along with researchers from the University of Zurich, was finally published in PLOS ONE. You can read it here http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0177158. If you want to dive into the survey data itself you’ll find all you need there as well!
 
-In order to show how crowdsourced citizen science can move genetics forward, we would love to get your height from a standardized form. This is why we kindly ask you to fill in this one question survey (it will not even take you a minute to answer!). : https://docs.google.com/forms/d/e/1FAIpQLSdOG0tZUaw1gD6MaFetjqyM6_jpwEgL74DnY15l9-hSZTalbA/viewform?entry.28571329=<%=@user.id%>
+The second thing we want to highlight is what Open Humans is doing. They are a non-profit community that enables sharing your data sets and connecting you with researchers and citizen scientists. Currently there are two projects about genetic data interpretation and visualization that might be of interest to you. Open Humans Co-founder Madeleine Ball wrote a brief introduction about the platform itself and the projects that might be of interest to you. You can find it below.
 
-Thanks so much for your support! If you have any questions regarding this research you can always contact us at info@openSNP.org or info@crowdAI.org.
+Until next time,
 
-The openSNP team and the crowdAI team
+Philipp and Bastian, for the openSNP-team
 
-[1] This might also be the first email you get regarding this, as our email system had some problem with getting blacklisted by GMail
+
+
+Dear openSNP member,
+
+I'd like to invite you to become a member of Open Humans, and highlight two projects in Open Humans that may be of particular interest or value to openSNP members.
+
+Open Humans is a nonprofit platform and community that gives you an ongoing profile for connecting and sharing your genetic and other data. We also make it easy for researchers and citizen scientists to create projects that others can join – enabling you to explore data and contribute to research in new ways.
+
+There are two projects in Open Humans you might be interested in, as they specifically invite individuals publicly sharing their genetic data:
+
+GenomiX Genome Exploration: Interested in genome data visualization? If you're already someone publicly sharing your 23andMe data, there's a research team that would love to work with you. A team led by Orit Shaer (Wellesley) and Oded Nov (NYU) have developed a genetic data exploration tool. Join their project and they'll invite you to participate in an online study this Spring/Summer that uses your own genetic data.
+
+Genevieve Genome Report: Genevieve is a tool that matches your data against ClinVar, a public database that aggregates information about genetic variants. To help improve shared understanding, Genevieve also invites users to contribute to shared, public, wiki-style notes. Because Genevieve uses a different matching algorithm, it has the potential to discover new information not available in your OpenSNP report.
+
+More about Open Humans: Launched in 2015, Open Humans is a program of the US-based 501(c)(3) nonprofit Open Humans Foundation (formerly called PersonalGenomes.org). Although it is not a study in itself, Open Humans allows you to join studies from a variety of academic institutions. In addition, members that join the optional Public Data Sharing study are able to publicly share data on the site, which is necessary for the two projects highlighted here. You can contact Open Humans for more information by emailing support@openhumans.org.
+
+Sincerely,
+
+Madeleine Ball, PhD
+
+Open Humans Co-founder Open Humans Foundation, Director of Research
 
 --
+
 You're receiving this email as your openSNP-settings say that you're okay with getting some emails from the openSNP-team. You can change this setting really easy at https://opensnp.org/users/<%=@user.id%>/edit#notifications


### PR DESCRIPTION
Should be ready to go. Last time we mailed survey-things via `sudo docker exec sidekiq bundle exec rake survey:send` from the `sidekiq`-host`.