### PR TITLE
Possible fix for CSS missing in Sidekiq web form

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,10 +12,11 @@ Snpr::Application.configure do
   config.action_controller.perform_caching = true
 
   # Specifies the header that your server uses for sending files
-  config.action_dispatch.x_sendfile_header = "X-Sendfile"
+  #config.action_dispatch.x_sendfile_header = "X-Sendfile"
 
   # For nginx:
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'
+  # see https://github.com/mperham/sidekiq/wiki/Problems-and-Troubleshooting#sidekiq-web-does-not-render-correctly-in-production-but-works-fine-in-development
+  config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'
 
   # If you have no front-end server that supports something like X-Sendfile,
   # just comment this out and Rails will serve the files

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,7 +12,7 @@ Snpr::Application.configure do
   config.action_controller.perform_caching = true
 
   # Specifies the header that your server uses for sending files
-  #config.action_dispatch.x_sendfile_header = "X-Sendfile"
+  # config.action_dispatch.x_sendfile_header = "X-Sendfile"
 
   # For nginx:
   # see https://github.com/mperham/sidekiq/wiki/Problems-and-Troubleshooting#sidekiq-web-does-not-render-correctly-in-production-but-works-fine-in-development
@@ -55,7 +55,7 @@ Snpr::Application.configure do
   # Compress JavaScript and CSS
   config.assets.compress = true
   config.assets.js_compressor = :uglifier
-  #config.assets.css_compressor = :yui
+  # config.assets.css_compressor = :yui
 
   # Don't fallback to assets pipeline
   config.assets.compile = false


### PR DESCRIPTION
We're currently (and have been for quite a while) missing the CSS and JS from the Sidekiq webform, but only in production.

Their FAQ says to just replace the production.rb sendfile_header: https://github.com/mperham/sidekiq/wiki/Problems-and-Troubleshooting#sidekiq-web-does-not-render-correctly-in-production-but-works-fine-in-development

This implements this, who knows whether it'll work, can't test for obvious reasons