### PR TITLE
Updates: Replaces sorting by created_at by sorting by ID, speed up the associated view

### DIFF
--- a/app/controllers/updates_controller.rb
+++ b/app/controllers/updates_controller.rb
@@ -2,17 +2,17 @@
 
 class UpdatesController < ApplicationController
   def index
-    @new_genotypes = Genotype.order('created_at DESC').limit(20)
-    @new_users = User.order('created_at DESC').limit(20)
-    @new_phenotypes = Phenotype.order('created_at DESC').limit(20)
-    @new_phenotype_comments = PhenotypeComment.order('created_at DESC').limit(20)
-    @new_snp_comments = SnpComment.order('created_at DESC').limit(20)
+    @new_genotypes = Genotype.order('id DESC').limit(20)
+    @new_users = User.order('id DESC').limit(20)
+    @new_phenotypes = Phenotype.order('id DESC').limit(20)
+    @new_phenotype_comments = PhenotypeComment.order('id DESC').limit(20)
+    @new_snp_comments = SnpComment.order('id DESC').limit(20)
 
-    @newest_plos_paper = PlosPaper.order('created_at DESC').limit(20)
-    @newest_mendeley_paper = MendeleyPaper.order('created_at DESC').limit(20)
+    @newest_plos_paper = PlosPaper.order('id DESC').limit(20)
+    @newest_mendeley_paper = MendeleyPaper.order('id DESC').limit(20)
 
     @newest_paper = @newest_mendeley_paper | @newest_plos_paper
-    @newest_paper.sort! { |a, b| b.created_at <=> a.created_at }
+    @newest_paper.sort! { |a, b| b.id <=> a.id }
 
     respond_to do |format|
       format.html

--- a/app/controllers/updates_controller.rb
+++ b/app/controllers/updates_controller.rb
@@ -2,6 +2,9 @@
 
 class UpdatesController < ApplicationController
   def index
+    @user_count = User.count
+    @genotype_count = Genotype.count
+
     @new_genotypes = Genotype.order('id DESC').limit(20)
     @new_users = User.order('id DESC').limit(20)
     @new_phenotypes = Phenotype.order('id DESC').limit(20)

--- a/app/views/updates/index.html.erb
+++ b/app/views/updates/index.html.erb
@@ -50,11 +50,11 @@
               <th>Joined on</th>
             </tr>
           </thead>
-          <% @new_users.each do |nu| %>
+          <% @new_users.each_with_index do |nu, index| %>
           <tr>
             <td class="table-cell vertical-centered"><%= link_to(image_tag(nu.avatar.url(:head), class: "img-circle", width: "50px") + " #{nu.name}", nu) %></td>
             <td class="table-cell vertical-centered"><%= nu.id %></td>
-            <td class="table-cell vertical-centered"><%= User.all.sort {|a,b| a.id <=> b.id}.index(nu) + 1 %></td>
+            <td class="table-cell vertical-centered"><%= @user_count - index %></td>
             <td class="table-cell vertical-centered"><%= nu.created_at %></td>
           </tr>
           <% end %>
@@ -79,10 +79,10 @@
               <th></th>
             </tr>
           </thead>
-          <% @new_genotypes.each do |ng| %>
+          <% @new_genotypes.each_with_index do |ng, index| %>
           <tr>
             <td class="table-cell vertical-centered"><%= link_to(image_tag(ng.user.avatar.url(:head), class: "img-circle", width: "50px") + " #{User.find(ng.user_id).name}", User.find(ng.user_id)) %></td>
-            <td class="table-cell vertical-centered"><%= Genotype.all.sort {|a,b| a.id <=> b.id}.index(ng) + 1 %></td>
+            <td class="table-cell vertical-centered"><%= @genotype_count - index %></td>
             <td class="table-cell vertical-centered"><%= ng.id %></td>
             <td class="table-cell vertical-centered"><%= ng.created_at %></td>
             <td class="table-cell vertical-centered"><%= link_to "Description", ng, class: "btn btn-default" %></td>


### PR DESCRIPTION
The updates controller is a bit slow, here's one way to make it a bit faster - instead of sorting by the 'created_at' field we sort by the `id` field. In Rails, the `id` field by default has an index, while the `created_at` field usually doesn't have one (we didn't make any). Instead of making indexes everywhere I just sort by ID, since the order of ID follows the order of `created_at`.

Benchmark on production:
Old:
```
2.3.3 :002 >       Benchmark.measure {@new_genotypes = Genotype.order('created_at DESC').limit(20)
2.3.3 :003?>       @new_users = User.order('created_at DESC').limit(20)
2.3.3 :004?>       @new_phenotypes = Phenotype.order('created_at DESC').limit(20)
2.3.3 :005?>       @new_phenotype_comments = PhenotypeComment.order('created_at DESC').limit(20)
2.3.3 :006?>       @new_snp_comments = SnpComment.order('created_at DESC').limit(20)
2.3.3 :007?>   
2.3.3 :008 >         @newest_plos_paper = PlosPaper.order('created_at DESC').limit(20)
2.3.3 :009?>       @newest_mendeley_paper = MendeleyPaper.order('created_at DESC').limit(20)
2.3.3 :010?>   
2.3.3 :011 >         @newest_paper = @newest_mendeley_paper | @newest_plos_paper
2.3.3 :012?>       @newest_paper.sort! { |a, b| b.created_at <=> a.created_at } }
 => #<Benchmark::Tms:0x0000000379e5c0 @label="", @real=0.11413506604731083, @cstime=0.0, @cutime=0.0, @stime=0.010000000000000675, @utime=0.040000000000000036, @total=0.05000000000000071> 
```

New:
```
2.3.3 :015 >   Benchmark.measure{
2.3.3 :016 >      @new_genotypes = Genotype.order('id DESC').limit(20)
2.3.3 :017?>       @new_users = User.order('id DESC').limit(20)
2.3.3 :018?>       @new_phenotypes = Phenotype.order('id DESC').limit(20)
2.3.3 :019?>       @new_phenotype_comments = PhenotypeComment.order('id DESC').limit(20)
2.3.3 :020?>       @new_snp_comments = SnpComment.order('id DESC').limit(20)
2.3.3 :021?>   
2.3.3 :022 >         @newest_plos_paper = PlosPaper.order('id DESC').limit(20)
2.3.3 :023?>       @newest_mendeley_paper = MendeleyPaper.order('id DESC').limit(20)
2.3.3 :024?>   
2.3.3 :025 >         @newest_paper = @newest_mendeley_paper | @newest_plos_paper
2.3.3 :026?>       @newest_paper.sort! { |a, b| b.id <=> a.id } }
 => #<Benchmark::Tms:0x0000000330da88 @label="", @real=0.011255990713834763, @cstime=0.0, @cutime=0.0, @stime=0.0, @utime=0.0, @total=0.0> 
```

The difference for real time is 5-10x.

I'm sure this isn't the last fix here.