### PR TITLE
two more for #375

### DIFF
--- a/app/views/genotypes/index.html.erb
+++ b/app/views/genotypes/index.html.erb
@@ -17,7 +17,6 @@
       <thead>
         <tr>
           <th>User</th>
-          <th>#</th>
           <th><%= sortable "id", "ID"%></th>
           <th><%= sortable "created_at", "Created"%></th>
           <th><%= sortable "filetype", "Type"%></th>
@@ -29,7 +28,6 @@
         <td class="table-cell vertical-centered">
           <%= link_to(image_tag(g.user.avatar.url(:head), :class => "img-circle", :width => "50px") + " #{g.user.name}", g.user) %>
         </td>
-        <td class="table-cell vertical-centered"><%= Genotype.all.sort { |a,b| a.id <=> b.id }.index(g) + 1 %></td>
         <td class="table-cell vertical-centered"><%= g.id %></td>
         <td class="table-cell vertical-centered"><%= g.created_at%></td>
         <td class="table-cell vertical-centered"><%= g.filetype %></td>

--- a/app/views/users/_user_is_not_user.html.erb
+++ b/app/views/users/_user_is_not_user.html.erb
@@ -41,7 +41,6 @@
 <ul class="nav nav-tabs" role="tablist">
   <li role="presentation" class="active"><a href="#genotypes" aria-controls="gentypes" role="tab" data-toggle="tab">Genotypes</a></li>
   <li role="presentation"><a href="#variations" aria-controls="variations" role="tab" data-toggle="tab">Variations</a></li>
-	<li role="presentation"><a ha href="#snps" aria-controls="snps" role="tab" data-toggle="tab"><%=@first_name%>'s SNPs</a></li>
 </ul>
 
 <div class="tab-content">
@@ -69,11 +68,4 @@
 		<% end %>
 	</div>
 
-	<div role="tabpanel" class="tab-pane well tabs__one-tab" id="snps">
-		<% if 1==2 %>
-			<%= render "snps" %>
-		<% else %>
-			<p>This user has not entered any snps yet.</p>
-		<% end %>
-	</div>
 </div>


### PR DESCRIPTION
- removes SNPs-tab from the user page
- removes slow indexing on genotypes index

these came back with the merging of the new UI.