### PR TITLE
Put back Rails specific config for SimpleCov

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@
 ENV['RAILS_ENV'] = 'test'
 unless ENV['CI']
   require 'simplecov'
-  SimpleCov.start
+  SimpleCov.start('rails')
 end
 require File.expand_path('../../config/environment', __FILE__)
 require "test/unit"


### PR DESCRIPTION
Without the `'rails'`, coverage drops to ~15% for the legacy tests, which probably means, it doesn't find all the tests.