### PR TITLE
Send message to user from their page now works

### DIFF
--- a/app/views/users/_user_is_not_user.html.erb
+++ b/app/views/users/_user_is_not_user.html.erb
@@ -13,7 +13,7 @@
 		<% if @user.description != nil %>
 		<p><%= @user.description %> </p>
 		<% end %>
-		<%= link_to("Send "+ @first_name + " a message", {:controller => "messages", :action => "new"}, :user_to_send => @user.id, class: "btn btn-primary userpage__new-messages") %>
+		<%= link_to("Send "+ @first_name + " a message", {:controller => "messages", :action => "new", :user_to_send => @user.id}, class: "btn btn-primary userpage__new-messages") %>
   </div>
 
 	<%if current_user%>


### PR DESCRIPTION
Before clicking on `send a message to this user` from a user show view would lead to an unfilled message form.