### PR TITLE
fixed modal autocomplete! closes #375

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -4,3 +4,6 @@
   *= require_self
   *= require style
  */
+ .ui-autocomplete{
+     z-index:1050;
+ }


### PR DESCRIPTION
This was a tough one! The issue was the CSS, not the JS! The `z-index` of the autocomplete CSS was too low and basically behind the modal. 

So technically it would all work, it just happened to be hidden by the modal. Can't tell you how long I spent with this bug and trying to figure out how to solve it! Hard to debug if you don't even get an error in your JS-console. 😂 😢 

This also solves what #409 tried to fix!