### PR TITLE
Fix modal disappearance, closes #176

### DIFF
--- a/app/views/layouts/_modal.html.erb
+++ b/app/views/layouts/_modal.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal">×</button>
+        <button id="modal_close_<%= id %>" type="button" class="close" data-dismiss="modal">×</button>
         <%= content_for id.to_sym%>
       </div>
       <div class="modal-body">

--- a/app/views/user_phenotypes/_new.html.erb
+++ b/app/views/user_phenotypes/_new.html.erb
@@ -25,6 +25,15 @@ $(document).ready(function() {
             $("label[for=user_phenotype_variation]").hide();
             });
 });
+
+// show the input-box when closing the modal
+$('#<%=id%>').on('hidden.bs.modal', function (e) {
+          $('<%="#phenotype_field"+phenotype.id.to_s%>').show();
+          $("label[for=user_phenotype_variation]").show();
+          $("#<%=id%>").find("input:radio").prop("checked", false).end()
+           .buttonset("refresh");
+});
+
 // Autocomplete for variations in the input-box
 $(function () {
     $('<%="#phenotype_field"+phenotype.id.to_s%>').autocomplete({

--- a/lib/tasks/update_mt_chromosome_name.rake
+++ b/lib/tasks/update_mt_chromosome_name.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :snps do
+  desc "change mitochondrial snp names from 'mt' to 'm'."
+  task :update_mt_snps => :environment do
+    Snp.where(:chromosome => "MT").each do |s|
+      s.chromosome = "M"
+      s.position = s.position.strip
+      s.save
+    end
+  end
+end

--- a/lib/tasks/update_mt_chromosome_name.rake
+++ b/lib/tasks/update_mt_chromosome_name.rake
@@ -2,11 +2,12 @@
 
 namespace :snps do
   desc "change mitochondrial snp names from 'mt' to 'm'."
-  task :update_mt_snps => :environment do
-    Snp.where(:chromosome => "MT").each do |s|
-      s.chromosome = "M"
+  task update_mt_snps: :environment do
+    Snp.where(chromosome: 'MT').each do |s|
+      s.chromosome = 'M'
       s.position = s.position.strip
       s.save
     end
+    puts 'updated MT positions'
   end
 end


### PR DESCRIPTION
This is another super old bug that's been around for a while. 

The issue was (#176): If a user opens a phenotype-entry modal on their dashboard, checks one of the radio buttons and closes it, the text entry field will disappear and can't be recovered unless they're doing a hard reload of the page.

What happens after this fix, when a user closes the modal: 
* The hidden elements are shown again
* the selected checkbox will be unchecked. 

This is more how the modal should behave after re-opening. 