### PR TITLE
Should stop bots from using sort and direction sortings

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,3 +4,5 @@
 # User-Agent: *
 # Disallow: /
 Disallow: /user_snps
+Disallow: /*sort=
+Disallow: /*direction=


### PR DESCRIPTION
This disallows from using `sort` and `direction` parameters as bots may cause server outages by asking many times for these computationally intensive views

As in:

```
               "path" : "/snps?direction=desc&page=206694&sort=chromosome",
               "path" : "/snps?direction=desc&page=206694&sort=chromosome",
               "path" : "/snps?direction=desc&page=191983&sort=position",
               "path" : "/snps?direction=asc&page=238042&sort=position",
               "path" : "/snps?direction=asc&page=221971&sort=id",
               "path" : "/snps?direction=desc&page=210945&sort=position",
               "path" : "/snps?direction=asc&page=238042&sort=position",
               "path" : "/snps?direction=asc&page=238042&sort=position",
```
