### PR TITLE
fix Open Humans profile index

### DIFF
--- a/app/views/open_humans_profiles/index.html.erb
+++ b/app/views/open_humans_profiles/index.html.erb
@@ -23,4 +23,7 @@
       <% end %>
     </table>
   </div>
+  <div class="text-center">
+    <%= page_navigation_links @oh_profiles %>
+  </div>
 </div>


### PR DESCRIPTION
I guess that's on the curse of being too successful 😂 😉 :

We now have over 15 Open Humans profiles linked to openSNP. Which is the point when the pagination kicks in. Only now I figured out that I forgot to add the menu elements that actually allow you to paginate 🤦‍♂️ 