### PR TITLE
Removes airbrake (for now)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,6 @@ gem 'dynamic_form'
 gem 'lograge'
 gem 'slop'
 
-# for errbit
-gem 'airbrake', '~> 4.0'
-
 # apis
 gem 'mendeley', git: 'https://github.com/tsujigiri/mendeley', branch: 'paging_search'
 gem 'plos', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,9 +62,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
-    airbrake (4.3.8)
-      builder
-      multi_json
     arel (6.0.4)
     ast (2.3.0)
     authlogic (3.6.0)
@@ -180,7 +177,6 @@ GEM
     minitest (5.10.2)
     mocha (1.2.1)
       metaclass (~> 0.0.1)
-    multi_json (1.12.1)
     nenv (0.3.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -392,7 +388,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import (>= 0.4.0)
-  airbrake (~> 4.0)
   authlogic
   bcrypt-ruby
   capistrano (~> 2.0)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-# This is the config to talk to opensnperr.herokuapp.com
-Airbrake.configure do |config|
-  config.api_key = ENV.fetch('ERRBIT_API_KEY')
-  config.host    = ENV.fetch('ERRBIT_HOST')
-  config.port    = 443
-  config.secure  = config.port == 443
-  config.environment_name = Rails.env.production? ? `hostname` : Rails.env
-end


### PR DESCRIPTION
Since nobody even remembers how to log in and the broken connection generates many errors in the log, let's remove errbit for now. This should lessen the load a little bit.

We are planning to set up our own errbit instance instead of doing it on a free Heroku instance, since the Heroku db always fills up immediately it's not so useful anyway.