### PR TITLE
Remove superfluous `respond_to` calls

### DIFF
--- a/app/controllers/achievements_controller.rb
+++ b/app/controllers/achievements_controller.rb
@@ -1,14 +1,8 @@
 # frozen_string_literal: true
+
 class AchievementsController < ApplicationController
-
-def show
-  @achievement = Achievement.find(params[:id])
-
-  @title = 'Achievements'
-  respond_to do |format|
-    format.html
-    format.xml
+  def show
+    @achievement = Achievement.find(params[:id])
+    @title = 'Achievements'
   end
-end
-
 end

--- a/app/controllers/fitbit_profiles_controller.rb
+++ b/app/controllers/fitbit_profiles_controller.rb
@@ -107,15 +107,9 @@ class FitbitProfilesController < ApplicationController
   def dump
     @fitbit_profile = FitbitProfile.find_by_id(params[:id]) || not_found
     FitbitDump.perform_async(@fitbit_profile.id,current_user.id)
-    respond_to do |format|
-      format.html
-    end
   end
 
   def info
-    respond_to do |format|
-      format.html
-    end
   end
 
   private

--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -3,11 +3,6 @@ class IndexController < ApplicationController
   def index
     if current_user
       redirect_to current_user
-    else
-      respond_to do |format|
-  		  format.html
-  		  format.xml 
-  	  end
     end
   end
 end

--- a/app/controllers/phenotypes_controller.rb
+++ b/app/controllers/phenotypes_controller.rb
@@ -40,11 +40,6 @@ class PhenotypesController < ApplicationController
 
     # Make list of phenotypes for autocomplete
     @phenotype_list = Phenotype.pluck(:characteristic).to_json
-
-    respond_to do |format|
-      format.html
-      format.xml
-    end
   end
 
   def create
@@ -132,10 +127,6 @@ class PhenotypesController < ApplicationController
                             params[:variation], current_user.email)
     @phenotype = Phenotype.find(params[:id])
     @variation = params[:variation]
-    respond_to do |format|
-      format.html
-      format.xml
-    end
   end
 
   def json_variation
@@ -156,10 +147,7 @@ class PhenotypesController < ApplicationController
       @result['error'] = 'Sorry, this phenotype doesn\'t exist'
     end
 
-    respond_to do |format|
-      format.json { render json: @result }
-    end
-
+    render json: @result
   end
 
   def json
@@ -186,9 +174,7 @@ class PhenotypesController < ApplicationController
       @results = json_element(params)
     end
 
-    respond_to do |format|
-      format.json { render json: @results }
-    end
+    render json: @results
   end
 
   def json_element(params)

--- a/app/controllers/picture_phenotypes_controller.rb
+++ b/app/controllers/picture_phenotypes_controller.rb
@@ -27,11 +27,6 @@ class PicturePhenotypesController < ApplicationController
     @phenotype = PicturePhenotype.new
     @user_phenotype = UserPicturePhenotype.new
     @title = 'Create a new picture phenotype'
-
-    respond_to do |format|
-      format.html
-      format.xml
-    end
   end
 
   def create
@@ -97,11 +92,6 @@ class PicturePhenotypesController < ApplicationController
       @user_phenotype = UserPicturePhenotype.find_by_user_id_and_picture_phenotype_id(current_user.id,@phenotype.id)
     else
       @user_phenotype = UserPicturePhenotype.new
-    end
-
-    respond_to do |format|
-      format.html
-      format.xml
     end
   end
 

--- a/app/controllers/snps_controller.rb
+++ b/app/controllers/snps_controller.rb
@@ -63,9 +63,7 @@ class SnpsController < ApplicationController
       @results = json_element(params)
     end
 
-    respond_to do |format|
-      format.json { render json: @results }
-    end
+    render json: @results
   end
 
   def make_annotation(result, snp, name)
@@ -168,9 +166,7 @@ class SnpsController < ApplicationController
     end
 
     @result = result
-    respond_to do |format|
-      format.json { render json: @result }
-    end
+    render json: @result
   end
 
   private

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -2,25 +2,13 @@
 class StaticController < ApplicationController
   def index
     @title = 'Welcome'
-    respond_to do |format|
-      format.html
-      format.xml # just for the hell of it
-    end
   end
 
   def faq
     @title = 'FAQ'
-    respond_to do |format|
-      format.html
-      format.xml
-    end
   end
 
   def press
     @title = 'openSNP in the press'
-    respond_to do |format|
-      format.html
-      format.xml
-    end
   end
 end

--- a/app/controllers/updates_controller.rb
+++ b/app/controllers/updates_controller.rb
@@ -16,9 +16,5 @@ class UpdatesController < ApplicationController
 
     @newest_paper = @newest_mendeley_paper | @newest_plos_paper
     @newest_paper.sort! { |a, b| b.id <=> a.id }
-
-    respond_to do |format|
-      format.html
-    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -113,18 +113,10 @@ class UsersController < ApplicationController
     @paginated_phenotype_replies = @phenotype_comment_replies
 
     @last_30_papers = LastUpdatedSnpsService.get_last_thirty_updated_snps(@user)
-    respond_to do |format|
-      format.html
-    end
   end
 
   def edit
     @user = User.find(params[:id])
-
-    respond_to do |format|
-      format.html
-      format.xml
-    end
   end
 
   def changepassword
@@ -153,15 +145,8 @@ class UsersController < ApplicationController
 
       if params[:user][:password] or params[:user][:avatar]
         redirect_to action: 'edit', id: current_user.id
-      else
-        respond_to do |format|
-          format.js
-          format.html
-        end
       end
-
     else
-
       respond_to do |format|
         format.html do
           if request.xhr?


### PR DESCRIPTION
Those are only necessary, if we actually do anything different for the different formats. Rails already looks up the correct templates for the requested formats, if there are any.

This may or may not fix https://sentry.io/opensnp/opensnp/issues/426098731/