### PR TITLE
Track releases in Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,5 +4,6 @@ if Rails.env.production?
   Raven.configure do |config|
     config.dsn = ENV.fetch('SENTRY_DSN')
     config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+    config.release = File.read('RELEASE').strip
   end
 end


### PR DESCRIPTION
The `RELEASE` file is written [here](https://github.com/openSNP/opensnp.org-docker/blob/2e4f1ad140dd90c4187aed58c7488ac2ba5f448f/Dockerfile#L29).