### PR TITLE
Sentry release tracking

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,6 +4,5 @@ if Rails.env.production?
   Raven.configure do |config|
     config.dsn = ENV.fetch('SENTRY_DSN')
     config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-    config.release = File.read('RELEASE').strip
   end
 end


### PR DESCRIPTION
Turns out, Raven auto-detects the version if the file is called "REVISION", instead.

See: https://github.com/getsentry/raven-ruby/blob/00c572b281b0862e2fbb7872b28c95e7c2578949/lib/raven/configuration.rb#L367
And: https://github.com/tsujigiri/opensnp.org-docker/commit/ae8db90f8ff4b3e645947df17fe754464fbdf4b3