### PR TITLE
Remove Ruby version from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
-ruby '>= 2.3.3'
 
 gem 'dotenv-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -453,8 +453,5 @@ DEPENDENCIES
   will_paginate
   will_paginate-bootstrap
 
-RUBY VERSION
-   ruby 2.3.3p222
-
 BUNDLED WITH
    1.16.0


### PR DESCRIPTION
Passenger complained that it couldn't find version 2.3 after I updated
the Docker image to use 2.4 and I'm not sure it makes sense to specify
the version if it has to be a specific one.

Alternatively we could set it to 2.4.3. This seems to even pin it to a patch level automatically. I'd expect this to be more problematic than helpful. What do you think?