### PR TITLE
Notify Sentry of new releases

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,6 +17,7 @@ export ERRBIT_HOST=localhost
 export OH_CLIENT_ID=foo
 export OH_CLIENT_SECRET=bar
 export SENTRY_DSN=foo
+export SENTRY_RELEASE_WEBHOOK=https://example.com/
 
 # username for smtp
 export SURVEY_EMAIL_USER=foobar

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,4 +5,11 @@ if Rails.env.production?
     config.dsn = ENV.fetch('SENTRY_DSN')
     config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
   end
+
+  # Notify Sentry of a new release.
+  Net::HTTP.post(
+    URI.parse(ENV.fetch('SENTRY_RELEASE_WEBHOOK')),
+    { 'version' => File.read('REVISION').strip }.to_json,
+    'Content-Type' => 'application/json'
+  )
 end


### PR DESCRIPTION
Usually Sentry only learns about releases once there is an exception. With these changes, we push this information to Sentry when Rails starts, which lets us keep track of all deployments.