### PR TITLE
Get a current dump from production

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11,7 +11,6 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,12 +2,11 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.1
--- Dumped by pg_dump version 10.1
+-- Dumped from database version 9.3.13
+-- Dumped by pg_dump version 9.5.10
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
@@ -654,7 +653,6 @@ CREATE TABLE open_humans_profiles (
 --
 
 CREATE SEQUENCE open_humans_profiles_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1237,210 +1235,210 @@ ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
--- Name: achievements id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY achievements ALTER COLUMN id SET DEFAULT nextval('achievements_id_seq'::regclass);
 
 
 --
--- Name: active_admin_comments id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY active_admin_comments ALTER COLUMN id SET DEFAULT nextval('active_admin_comments_id_seq'::regclass);
 
 
 --
--- Name: admin_users id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY admin_users ALTER COLUMN id SET DEFAULT nextval('admin_users_id_seq'::regclass);
 
 
 --
--- Name: file_links id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY file_links ALTER COLUMN id SET DEFAULT nextval('file_links_id_seq'::regclass);
 
 
 --
--- Name: fitbit_activities id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY fitbit_activities ALTER COLUMN id SET DEFAULT nextval('fitbit_activities_id_seq'::regclass);
 
 
 --
--- Name: fitbit_bodies id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY fitbit_bodies ALTER COLUMN id SET DEFAULT nextval('fitbit_bodies_id_seq'::regclass);
 
 
 --
--- Name: fitbit_profiles id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY fitbit_profiles ALTER COLUMN id SET DEFAULT nextval('fitbit_profiles_id_seq'::regclass);
 
 
 --
--- Name: fitbit_sleeps id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY fitbit_sleeps ALTER COLUMN id SET DEFAULT nextval('fitbit_sleeps_id_seq'::regclass);
 
 
 --
--- Name: friendly_id_slugs id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY friendly_id_slugs ALTER COLUMN id SET DEFAULT nextval('friendly_id_slugs_id_seq'::regclass);
 
 
 --
--- Name: genome_gov_papers id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY genome_gov_papers ALTER COLUMN id SET DEFAULT nextval('genome_gov_papers_id_seq'::regclass);
 
 
 --
--- Name: genotypes id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY genotypes ALTER COLUMN id SET DEFAULT nextval('genotypes_id_seq'::regclass);
 
 
 --
--- Name: homepages id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY homepages ALTER COLUMN id SET DEFAULT nextval('homepages_id_seq'::regclass);
 
 
 --
--- Name: mendeley_papers id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY mendeley_papers ALTER COLUMN id SET DEFAULT nextval('mendeley_papers_id_seq'::regclass);
 
 
 --
--- Name: messages id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY messages ALTER COLUMN id SET DEFAULT nextval('messages_id_seq'::regclass);
 
 
 --
--- Name: open_humans_profiles id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY open_humans_profiles ALTER COLUMN id SET DEFAULT nextval('open_humans_profiles_id_seq'::regclass);
 
 
 --
--- Name: pgp_annotations id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY pgp_annotations ALTER COLUMN id SET DEFAULT nextval('pgp_annotations_id_seq'::regclass);
 
 
 --
--- Name: phenotype_comments id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY phenotype_comments ALTER COLUMN id SET DEFAULT nextval('phenotype_comments_id_seq'::regclass);
 
 
 --
--- Name: phenotype_sets id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY phenotype_sets ALTER COLUMN id SET DEFAULT nextval('phenotype_sets_id_seq'::regclass);
 
 
 --
--- Name: phenotypes id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY phenotypes ALTER COLUMN id SET DEFAULT nextval('phenotypes_id_seq'::regclass);
 
 
 --
--- Name: picture_phenotype_comments id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY picture_phenotype_comments ALTER COLUMN id SET DEFAULT nextval('picture_phenotype_comments_id_seq'::regclass);
 
 
 --
--- Name: picture_phenotypes id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY picture_phenotypes ALTER COLUMN id SET DEFAULT nextval('picture_phenotypes_id_seq'::regclass);
 
 
 --
--- Name: plos_papers id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY plos_papers ALTER COLUMN id SET DEFAULT nextval('plos_papers_id_seq'::regclass);
 
 
 --
--- Name: snp_comments id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY snp_comments ALTER COLUMN id SET DEFAULT nextval('snp_comments_id_seq'::regclass);
 
 
 --
--- Name: snpedia_papers id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY snpedia_papers ALTER COLUMN id SET DEFAULT nextval('snpedia_papers_id_seq'::regclass);
 
 
 --
--- Name: snps id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY snps ALTER COLUMN id SET DEFAULT nextval('snps_id_seq'::regclass);
 
 
 --
--- Name: user_achievements id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_achievements ALTER COLUMN id SET DEFAULT nextval('user_achievements_id_seq'::regclass);
 
 
 --
--- Name: user_phenotypes id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_phenotypes ALTER COLUMN id SET DEFAULT nextval('user_phenotypes_id_seq'::regclass);
 
 
 --
--- Name: user_picture_phenotypes id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_picture_phenotypes ALTER COLUMN id SET DEFAULT nextval('user_picture_phenotypes_id_seq'::regclass);
 
 
 --
--- Name: users id; Type: DEFAULT; Schema: public; Owner: -
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
 
 
 --
--- Name: achievements achievements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: achievements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY achievements
@@ -1448,7 +1446,7 @@ ALTER TABLE ONLY achievements
 
 
 --
--- Name: active_admin_comments admin_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: admin_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY active_admin_comments
@@ -1456,7 +1454,7 @@ ALTER TABLE ONLY active_admin_comments
 
 
 --
--- Name: admin_users admin_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: admin_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY admin_users
@@ -1464,7 +1462,7 @@ ALTER TABLE ONLY admin_users
 
 
 --
--- Name: file_links file_links_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: file_links_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY file_links
@@ -1472,7 +1470,7 @@ ALTER TABLE ONLY file_links
 
 
 --
--- Name: fitbit_activities fitbit_activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: fitbit_activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY fitbit_activities
@@ -1480,7 +1478,7 @@ ALTER TABLE ONLY fitbit_activities
 
 
 --
--- Name: fitbit_bodies fitbit_bodies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: fitbit_bodies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY fitbit_bodies
@@ -1488,7 +1486,7 @@ ALTER TABLE ONLY fitbit_bodies
 
 
 --
--- Name: fitbit_profiles fitbit_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: fitbit_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY fitbit_profiles
@@ -1496,7 +1494,7 @@ ALTER TABLE ONLY fitbit_profiles
 
 
 --
--- Name: fitbit_sleeps fitbit_sleeps_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: fitbit_sleeps_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY fitbit_sleeps
@@ -1504,7 +1502,7 @@ ALTER TABLE ONLY fitbit_sleeps
 
 
 --
--- Name: friendly_id_slugs friendly_id_slugs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: friendly_id_slugs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY friendly_id_slugs
@@ -1512,7 +1510,7 @@ ALTER TABLE ONLY friendly_id_slugs
 
 
 --
--- Name: genome_gov_papers genome_gov_papers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: genome_gov_papers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY genome_gov_papers
@@ -1520,7 +1518,7 @@ ALTER TABLE ONLY genome_gov_papers
 
 
 --
--- Name: genotypes genotypes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: genotypes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY genotypes
@@ -1528,7 +1526,7 @@ ALTER TABLE ONLY genotypes
 
 
 --
--- Name: homepages homepages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: homepages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY homepages
@@ -1536,7 +1534,7 @@ ALTER TABLE ONLY homepages
 
 
 --
--- Name: mendeley_papers mendeley_papers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: mendeley_papers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY mendeley_papers
@@ -1544,7 +1542,7 @@ ALTER TABLE ONLY mendeley_papers
 
 
 --
--- Name: messages messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY messages
@@ -1552,7 +1550,7 @@ ALTER TABLE ONLY messages
 
 
 --
--- Name: open_humans_profiles open_humans_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: open_humans_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY open_humans_profiles
@@ -1560,7 +1558,7 @@ ALTER TABLE ONLY open_humans_profiles
 
 
 --
--- Name: pgp_annotations pgp_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: pgp_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY pgp_annotations
@@ -1568,7 +1566,7 @@ ALTER TABLE ONLY pgp_annotations
 
 
 --
--- Name: phenotype_comments phenotype_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: phenotype_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY phenotype_comments
@@ -1576,7 +1574,7 @@ ALTER TABLE ONLY phenotype_comments
 
 
 --
--- Name: phenotype_sets phenotype_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: phenotype_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY phenotype_sets
@@ -1584,7 +1582,7 @@ ALTER TABLE ONLY phenotype_sets
 
 
 --
--- Name: phenotypes phenotypes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: phenotypes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY phenotypes
@@ -1592,7 +1590,7 @@ ALTER TABLE ONLY phenotypes
 
 
 --
--- Name: picture_phenotype_comments picture_phenotype_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: picture_phenotype_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY picture_phenotype_comments
@@ -1600,7 +1598,7 @@ ALTER TABLE ONLY picture_phenotype_comments
 
 
 --
--- Name: picture_phenotypes picture_phenotypes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: picture_phenotypes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY picture_phenotypes
@@ -1608,7 +1606,7 @@ ALTER TABLE ONLY picture_phenotypes
 
 
 --
--- Name: plos_papers plos_papers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: plos_papers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY plos_papers
@@ -1616,7 +1614,7 @@ ALTER TABLE ONLY plos_papers
 
 
 --
--- Name: snp_comments snp_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: snp_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY snp_comments
@@ -1624,7 +1622,7 @@ ALTER TABLE ONLY snp_comments
 
 
 --
--- Name: snpedia_papers snpedia_papers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: snpedia_papers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY snpedia_papers
@@ -1632,7 +1630,7 @@ ALTER TABLE ONLY snpedia_papers
 
 
 --
--- Name: snps snps_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: snps_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY snps
@@ -1640,7 +1638,7 @@ ALTER TABLE ONLY snps
 
 
 --
--- Name: user_achievements user_achievements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: user_achievements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_achievements
@@ -1648,7 +1646,7 @@ ALTER TABLE ONLY user_achievements
 
 
 --
--- Name: user_phenotypes user_phenotypes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: user_phenotypes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_phenotypes
@@ -1656,7 +1654,7 @@ ALTER TABLE ONLY user_phenotypes
 
 
 --
--- Name: user_picture_phenotypes user_picture_phenotypes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: user_picture_phenotypes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_picture_phenotypes
@@ -1664,7 +1662,7 @@ ALTER TABLE ONLY user_picture_phenotypes
 
 
 --
--- Name: user_snps user_snps_new_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: user_snps_new_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_snps
@@ -1672,7 +1670,7 @@ ALTER TABLE ONLY user_snps
 
 
 --
--- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users
@@ -1820,7 +1818,21 @@ CREATE INDEX snps_position_idx ON snps USING btree ("position");
 
 
 --
--- Name: fitbit_profiles fitbit_profiles_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: user_phenotypes_phenotype_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_phenotypes_phenotype_id_idx ON user_phenotypes USING btree (phenotype_id);
+
+
+--
+-- Name: user_phenotypes_user_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_phenotypes_user_id_idx ON user_phenotypes USING btree (user_id);
+
+
+--
+-- Name: fitbit_profiles_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY fitbit_profiles
@@ -1828,7 +1840,7 @@ ALTER TABLE ONLY fitbit_profiles
 
 
 --
--- Name: genotypes genotypes_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: genotypes_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY genotypes
@@ -1836,7 +1848,7 @@ ALTER TABLE ONLY genotypes
 
 
 --
--- Name: homepages homepages_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: homepages_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY homepages
@@ -1844,7 +1856,7 @@ ALTER TABLE ONLY homepages
 
 
 --
--- Name: phenotype_comments phenotype_comments_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: phenotype_comments_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY phenotype_comments
@@ -1852,7 +1864,7 @@ ALTER TABLE ONLY phenotype_comments
 
 
 --
--- Name: picture_phenotype_comments picture_phenotype_comments_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: picture_phenotype_comments_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY picture_phenotype_comments
@@ -1860,7 +1872,7 @@ ALTER TABLE ONLY picture_phenotype_comments
 
 
 --
--- Name: user_achievements user_achievements_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: user_achievements_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_achievements
@@ -1868,7 +1880,7 @@ ALTER TABLE ONLY user_achievements
 
 
 --
--- Name: user_phenotypes user_phenotypes_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: user_phenotypes_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_phenotypes
@@ -1876,7 +1888,7 @@ ALTER TABLE ONLY user_phenotypes
 
 
 --
--- Name: user_picture_phenotypes user_picture_phenotypes_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: user_picture_phenotypes_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_picture_phenotypes
@@ -1884,7 +1896,7 @@ ALTER TABLE ONLY user_picture_phenotypes
 
 
 --
--- Name: user_snps user_snps_genotype_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: user_snps_genotype_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY user_snps
@@ -1895,273 +1907,139 @@ ALTER TABLE ONLY user_snps
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO "$user", public;
-
-INSERT INTO schema_migrations (version) VALUES ('20110608000645');
+SET search_path TO "$user",public;
 
 INSERT INTO schema_migrations (version) VALUES ('20110608000645');
 
 INSERT INTO schema_migrations (version) VALUES ('20110615045458');
 
-INSERT INTO schema_migrations (version) VALUES ('20110615045458');
-
 INSERT INTO schema_migrations (version) VALUES ('20110615173154');
-
-INSERT INTO schema_migrations (version) VALUES ('20110615173154');
-
-INSERT INTO schema_migrations (version) VALUES ('20110616192820');
 
 INSERT INTO schema_migrations (version) VALUES ('20110616192820');
 
 INSERT INTO schema_migrations (version) VALUES ('20110617144145');
 
-INSERT INTO schema_migrations (version) VALUES ('20110617144145');
-
 INSERT INTO schema_migrations (version) VALUES ('20110819233120');
-
-INSERT INTO schema_migrations (version) VALUES ('20110819233120');
-
-INSERT INTO schema_migrations (version) VALUES ('20110820195410');
 
 INSERT INTO schema_migrations (version) VALUES ('20110820195410');
 
 INSERT INTO schema_migrations (version) VALUES ('20110821112909');
 
-INSERT INTO schema_migrations (version) VALUES ('20110821112909');
-
 INSERT INTO schema_migrations (version) VALUES ('20110822071221');
-
-INSERT INTO schema_migrations (version) VALUES ('20110822071221');
-
-INSERT INTO schema_migrations (version) VALUES ('20110822110806');
 
 INSERT INTO schema_migrations (version) VALUES ('20110822110806');
 
 INSERT INTO schema_migrations (version) VALUES ('20110823032055');
 
-INSERT INTO schema_migrations (version) VALUES ('20110823032055');
-
 INSERT INTO schema_migrations (version) VALUES ('20110824164934');
-
-INSERT INTO schema_migrations (version) VALUES ('20110824164934');
-
-INSERT INTO schema_migrations (version) VALUES ('20110830134100');
 
 INSERT INTO schema_migrations (version) VALUES ('20110830134100');
 
 INSERT INTO schema_migrations (version) VALUES ('20110912190409');
 
-INSERT INTO schema_migrations (version) VALUES ('20110912190409');
-
 INSERT INTO schema_migrations (version) VALUES ('20110914100443');
-
-INSERT INTO schema_migrations (version) VALUES ('20110914100443');
-
-INSERT INTO schema_migrations (version) VALUES ('20110914100516');
 
 INSERT INTO schema_migrations (version) VALUES ('20110914100516');
 
 INSERT INTO schema_migrations (version) VALUES ('20110914151105');
 
-INSERT INTO schema_migrations (version) VALUES ('20110914151105');
-
 INSERT INTO schema_migrations (version) VALUES ('20110917193600');
-
-INSERT INTO schema_migrations (version) VALUES ('20110917193600');
-
-INSERT INTO schema_migrations (version) VALUES ('20110926092220');
 
 INSERT INTO schema_migrations (version) VALUES ('20110926092220');
 
 INSERT INTO schema_migrations (version) VALUES ('20110926172905');
 
-INSERT INTO schema_migrations (version) VALUES ('20110926172905');
-
 INSERT INTO schema_migrations (version) VALUES ('20111005210020');
-
-INSERT INTO schema_migrations (version) VALUES ('20111005210020');
-
-INSERT INTO schema_migrations (version) VALUES ('20111006133700');
 
 INSERT INTO schema_migrations (version) VALUES ('20111006133700');
 
 INSERT INTO schema_migrations (version) VALUES ('20111006163700');
 
-INSERT INTO schema_migrations (version) VALUES ('20111006163700');
-
 INSERT INTO schema_migrations (version) VALUES ('20111007141500');
-
-INSERT INTO schema_migrations (version) VALUES ('20111007141500');
-
-INSERT INTO schema_migrations (version) VALUES ('20111007145000');
 
 INSERT INTO schema_migrations (version) VALUES ('20111007145000');
 
 INSERT INTO schema_migrations (version) VALUES ('20111018040633');
 
-INSERT INTO schema_migrations (version) VALUES ('20111018040633');
-
 INSERT INTO schema_migrations (version) VALUES ('20111028190606');
-
-INSERT INTO schema_migrations (version) VALUES ('20111028190606');
-
-INSERT INTO schema_migrations (version) VALUES ('20111028212506');
 
 INSERT INTO schema_migrations (version) VALUES ('20111028212506');
 
 INSERT INTO schema_migrations (version) VALUES ('20111029180506');
 
-INSERT INTO schema_migrations (version) VALUES ('20111029180506');
-
 INSERT INTO schema_migrations (version) VALUES ('20111102033039');
-
-INSERT INTO schema_migrations (version) VALUES ('20111102033039');
-
-INSERT INTO schema_migrations (version) VALUES ('20111212063354');
 
 INSERT INTO schema_migrations (version) VALUES ('20111212063354');
 
 INSERT INTO schema_migrations (version) VALUES ('20120208020405');
 
-INSERT INTO schema_migrations (version) VALUES ('20120208020405');
-
 INSERT INTO schema_migrations (version) VALUES ('20120324143135');
-
-INSERT INTO schema_migrations (version) VALUES ('20120324143135');
-
-INSERT INTO schema_migrations (version) VALUES ('20120509234035');
 
 INSERT INTO schema_migrations (version) VALUES ('20120509234035');
 
 INSERT INTO schema_migrations (version) VALUES ('20120902113435');
 
-INSERT INTO schema_migrations (version) VALUES ('20120902113435');
-
 INSERT INTO schema_migrations (version) VALUES ('20120902174500');
-
-INSERT INTO schema_migrations (version) VALUES ('20120902174500');
-
-INSERT INTO schema_migrations (version) VALUES ('20120902175000');
 
 INSERT INTO schema_migrations (version) VALUES ('20120902175000');
 
 INSERT INTO schema_migrations (version) VALUES ('20120902175500');
 
-INSERT INTO schema_migrations (version) VALUES ('20120902175500');
-
 INSERT INTO schema_migrations (version) VALUES ('20120916211800');
-
-INSERT INTO schema_migrations (version) VALUES ('20120916211800');
-
-INSERT INTO schema_migrations (version) VALUES ('20120916212700');
 
 INSERT INTO schema_migrations (version) VALUES ('20120916212700');
 
 INSERT INTO schema_migrations (version) VALUES ('20121006230458');
 
-INSERT INTO schema_migrations (version) VALUES ('20121006230458');
-
 INSERT INTO schema_migrations (version) VALUES ('20121020153113');
-
-INSERT INTO schema_migrations (version) VALUES ('20121020153113');
-
-INSERT INTO schema_migrations (version) VALUES ('20121023032404');
 
 INSERT INTO schema_migrations (version) VALUES ('20121023032404');
 
 INSERT INTO schema_migrations (version) VALUES ('20121123234958');
 
-INSERT INTO schema_migrations (version) VALUES ('20121123234958');
-
 INSERT INTO schema_migrations (version) VALUES ('20121123235228');
-
-INSERT INTO schema_migrations (version) VALUES ('20121123235228');
-
-INSERT INTO schema_migrations (version) VALUES ('20121124201111');
 
 INSERT INTO schema_migrations (version) VALUES ('20121124201111');
 
 INSERT INTO schema_migrations (version) VALUES ('20121210131554');
 
-INSERT INTO schema_migrations (version) VALUES ('20121210131554');
-
 INSERT INTO schema_migrations (version) VALUES ('20121213120010');
-
-INSERT INTO schema_migrations (version) VALUES ('20121213120010');
-
-INSERT INTO schema_migrations (version) VALUES ('20130124085042');
 
 INSERT INTO schema_migrations (version) VALUES ('20130124085042');
 
 INSERT INTO schema_migrations (version) VALUES ('20130608135719');
 
-INSERT INTO schema_migrations (version) VALUES ('20130608135719');
-
 INSERT INTO schema_migrations (version) VALUES ('20130904010945');
-
-INSERT INTO schema_migrations (version) VALUES ('20130904010945');
-
-INSERT INTO schema_migrations (version) VALUES ('20130904010949');
 
 INSERT INTO schema_migrations (version) VALUES ('20130904010949');
 
 INSERT INTO schema_migrations (version) VALUES ('20130904010950');
 
-INSERT INTO schema_migrations (version) VALUES ('20130904010950');
-
 INSERT INTO schema_migrations (version) VALUES ('20131117101353');
-
-INSERT INTO schema_migrations (version) VALUES ('20131117101353');
-
-INSERT INTO schema_migrations (version) VALUES ('20131130123430');
 
 INSERT INTO schema_migrations (version) VALUES ('20131130123430');
 
 INSERT INTO schema_migrations (version) VALUES ('20140120005457');
 
-INSERT INTO schema_migrations (version) VALUES ('20140120005457');
-
 INSERT INTO schema_migrations (version) VALUES ('20140221060607');
-
-INSERT INTO schema_migrations (version) VALUES ('20140221060607');
-
-INSERT INTO schema_migrations (version) VALUES ('20140509001806');
 
 INSERT INTO schema_migrations (version) VALUES ('20140509001806');
 
 INSERT INTO schema_migrations (version) VALUES ('20140820071334');
 
-INSERT INTO schema_migrations (version) VALUES ('20140820071334');
-
 INSERT INTO schema_migrations (version) VALUES ('20150524081137');
-
-INSERT INTO schema_migrations (version) VALUES ('20150524081137');
-
-INSERT INTO schema_migrations (version) VALUES ('20150916070052');
 
 INSERT INTO schema_migrations (version) VALUES ('20150916070052');
 
 INSERT INTO schema_migrations (version) VALUES ('20151019160643');
 
-INSERT INTO schema_migrations (version) VALUES ('20151019160643');
-
 INSERT INTO schema_migrations (version) VALUES ('20151028130755');
-
-INSERT INTO schema_migrations (version) VALUES ('20151028130755');
-
-INSERT INTO schema_migrations (version) VALUES ('20151119070640');
 
 INSERT INTO schema_migrations (version) VALUES ('20151119070640');
 
 INSERT INTO schema_migrations (version) VALUES ('20160207043305');
 
-INSERT INTO schema_migrations (version) VALUES ('20160207043305');
-
 INSERT INTO schema_migrations (version) VALUES ('20160626121340');
-
-INSERT INTO schema_migrations (version) VALUES ('20160626121340');
-
-INSERT INTO schema_migrations (version) VALUES ('20160806143618');
 
 INSERT INTO schema_migrations (version) VALUES ('20160806143618');
 


### PR DESCRIPTION
The current SQL dump is causing errors on TravisCI is because it's done with a recent version (by running `db:migrate`), while we use 9.3 on production and TravisCI. I suppose the only way to really fix this is to upgrade Postgres in production, for now this should at least work to fix the tests.
  