### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/app/controllers/snps_controller.rb
+++ b/app/controllers/snps_controller.rb
@@ -96,7 +96,7 @@ class SnpsController < ApplicationController
       @plos['title'] = mp.title
       @plos['publication_date'] = mp.pub_date
       @plos['number_of_readers'] = mp.reader
-      @plos['url'] = 'https://doi.org/'+mp.doi
+      @plos['url'] = 'https://doi.org/' + mp.doi
       @plos['doi'] = mp.doi
       result[name]['annotations']['plos'] << @plos
     end

--- a/app/controllers/snps_controller.rb
+++ b/app/controllers/snps_controller.rb
@@ -96,7 +96,7 @@ class SnpsController < ApplicationController
       @plos['title'] = mp.title
       @plos['publication_date'] = mp.pub_date
       @plos['number_of_readers'] = mp.reader
-      @plos['url'] = 'http://dx.doi.org/'+mp.doi
+      @plos['url'] = 'https://doi.org/'+mp.doi
       @plos['doi'] = mp.doi
       result[name]['annotations']['plos'] << @plos
     end

--- a/app/views/news/paper_rss.rss.builder
+++ b/app/views/news/paper_rss.rss.builder
@@ -15,7 +15,7 @@ xml.rss :version => "2.0" do
                   xml.guid "mendeley_"+paper.id.to_s
                 elsif paper.class == PlosPaper
                   xml.description "The paper \""+paper.title+"\" is about SNP "+snp.name+" and was published in one of the PLoS journals in "+paper.pub_date.to_s[6,4]+" by "+paper.first_author+ " et al. and so far "+paper.reader.to_s+" people have read it there."
-                  xml.link "http://dx.doi.org/"+paper.doi
+                  xml.link "https://doi.org/"+paper.doi
                   xml.guid "plos_"+paper.id.to_s 
                 end
                end

--- a/app/views/search_results/search.html.erb
+++ b/app/views/search_results/search.html.erb
@@ -182,9 +182,9 @@
               <td class="table-cell vertical-centered"><%= p.pub_year %></td>
               <td class="table-cell vertical-centered"><%= p.reader %></td>
               <% if p.open_access && p.doi %>
-              <td class="table-cell vertical-centered"><%= link_to(p.doi,"http://dx.doi.org/#{p.doi}") %><%= image_tag("oa_logo.png") %></td>
+              <td class="table-cell vertical-centered"><%= link_to(p.doi,"https://doi.org/#{p.doi}") %><%= image_tag("oa_logo.png") %></td>
               <% elsif p.doi != nil %>
-              <td class="table-cell vertical-centered"><%= link_to(p.doi,"http://dx.doi.org/#{p.doi}") %></td>
+              <td class="table-cell vertical-centered"><%= link_to(p.doi,"https://doi.org/#{p.doi}") %></td>
               <% elsif p.open_access == true %>
               <td class="table-cell vertical-centered"><%= p.doi %><%= image_tag("oa_logo.png") %></td>
               <% else %>
@@ -211,7 +211,7 @@
             <% @plos_papers.each do |p| %>
             <tr>
               <td class="table-cell vertical-centered"><%= p.first_author %></td>
-              <td class="table-cell vertical-centered"><%= link_to( p.title.html_safe, "http://dx.doi.org/#{p.doi}") %></td>
+              <td class="table-cell vertical-centered"><%= link_to( p.title.html_safe, "https://doi.org/#{p.doi}") %></td>
               <td class="table-cell vertical-centered"><% p.snps.each do |x| %> <%= link_to( x.name, x) %> <% end %></td>
               <td class="table-cell vertical-centered"><%= p.pub_date.to_s[6,4] %></td>
               <td class="table-cell vertical-centered"><%= p.reader %></td>

--- a/app/views/snps/show.html.erb
+++ b/app/views/snps/show.html.erb
@@ -105,7 +105,7 @@
             <% @snp.plos_papers.limit(100).each do |p|%>
             <tr>
               <td class="table-cell vertical-centered"><%=p.first_author%></td>
-              <td class="table-cell vertical-centered"><%=link_to(p.title.html_safe, "http://dx.doi.org/#{p.doi}")%></td>
+              <td class="table-cell vertical-centered"><%=link_to(p.title.html_safe, "https://doi.org/#{p.doi}")%></td>
               <td class="table-cell vertical-centered"><%=p.pub_date.to_s[6,4]%></td>
               <td class="table-cell vertical-centered"><%=p.reader%></td>
             </tr>
@@ -140,9 +140,9 @@
               <td class="table-cell vertical-centered"><%=p.pub_year%></td>
               <td class="table-cell vertical-centered"><%=p.reader%></td>
               <% if p.open_access == true and p.doi != nil%>
-              <td class="table-cell vertical-centered"><%=link_to(p.doi,"http://dx.doi.org/"+p.doi)%><%= image_tag("oa_logo.png") %></td>
+              <td class="table-cell vertical-centered"><%=link_to(p.doi,"https://doi.org/"+p.doi)%><%= image_tag("oa_logo.png") %></td>
               <%elsif p.doi != nil%>
-              <td class="table-cell vertical-centered"><%=link_to(p.doi,"http://dx.doi.org/"+p.doi)%></td>
+              <td class="table-cell vertical-centered"><%=link_to(p.doi,"https://doi.org/"+p.doi)%></td>
               <%elsif p.open_access == true%>
               <td class="table-cell vertical-centered"><%=p.doi%><%= image_tag("oa_logo.png") %></td>
               <%else%>

--- a/app/views/updates/index.html.erb
+++ b/app/views/updates/index.html.erb
@@ -26,7 +26,7 @@
           <tr>
             <td class="table-cell vertical-centered"><%=np.first_author%></td>
             <%if np.class == PlosPaper%>
-            <td class="table-cell vertical-centered"><%= link_to( np.title.html_safe, "http://dx.doi.org/"+np.doi)%></td>
+            <td class="table-cell vertical-centered"><%= link_to( np.title.html_safe, "https://doi.org/"+np.doi)%></td>
             <%else%>
             <td class="table-cell vertical-centered"><%=link_to( np.title, np.mendeley_url)%></td>
             <%end%>


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by updating the code that generates new DOI-URLs.

Cheers :-)