### PR TITLE
Explicitly set file permissions to 0644

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-Paperclip::Attachment.default_options[:overwrite_file_permissions] = false
+Paperclip::Attachment.default_options[:overwrite_file_permissions] = 0o644


### PR DESCRIPTION
Skipping the permission-setting didn't do the trick, let's try the sledgehammer method.